### PR TITLE
한투 api 사용을 위한 DTO 파일 추가

### DIFF
--- a/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
@@ -1,0 +1,156 @@
+package com.trueedu.spac.api.model.dto.account
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccountResponse(
+    val output1: List<AccountAsset>,
+    val output2: List<AccountDetail>,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0510"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+
+    // 다음 연속 조회시 사용
+    @SerialName("ctx_area_fk100")
+    val fk100: String, // 연속조회검색조건100
+    @SerialName("ctx_area_nk100")
+    val nk100: String, // 연속조회키100
+)
+
+@Serializable
+data class AccountAsset(
+    @SerialName("pdno")
+    val code: String, // 상품번호 (종목코드)
+    @SerialName("prdt_name")
+    val nameKr: String, // 상품명
+    @SerialName("trad_dvsn_name")
+    val tradeType: String, // 매매구분명 - "현금"
+    @SerialName("bfdy_buy_qty")
+    val prevDayBuyQuantity: String, // 전일매수수량
+    @SerialName("bfdy_sll_qty")
+    val prevDaySellQuantity: String, // 금일매수수량
+    @SerialName("thdt_buyqty") // api 문서가 오타인데 실제로 값도 이렇게 옴
+    val todayBuyQuantity: String, // 금일매수수량
+    @SerialName("thdt_sll_qty")
+    val todaySellQuantity: String, // 금일매도수량
+    @SerialName("hldg_qty")
+    val holdingQuantity: String, // 보유수량
+    @SerialName("ord_psbl_qty")
+    val orderPossibleQuantity: String, // 주문가능수량
+    @SerialName("pchs_avg_pric")
+    val purchaseAveragePrice: String, // 매입평균가격
+    @SerialName("pchs_amt")
+    val purchaseAmount: String, // 매입금액
+    @SerialName("prpr")
+    val currentPrice: String, // 현재가
+    @SerialName("evlu_amt")
+    val evaluationAmount: String, // 평가금액
+    @SerialName("evlu_pfls_amt")
+    val profitLossAmount: String, // 평가손익금액
+    @SerialName("evlu_pfls_rt")
+    val profitLossRate: String, // 평가손익율
+    @SerialName("evlu_erng_rt")
+    val evaluationEarningsRate: String, // 평가수익율
+    @SerialName("loan_dt")
+    val loanDate: String, // 대출일자 - INQR_DVSN(조회구분)을 01(대출일별)로 설정해야 값이 나옴
+    @SerialName("loan_amt")
+    val loanAmount: String, // 대출금액
+    @SerialName("stln_slng_chgs")
+    val settlementSellingCharges: String, // 대주매각대금
+    @SerialName("expd_dt")
+    val expirationDate: String, // 만기일자
+    @SerialName("fltt_rt")
+    val priceChangeRate: String, // 전일 대비 등락율
+    @SerialName("bfdy_cprs_icdc")
+    val priceChange: String, // 전일대비증감 (주식 가격)
+    @SerialName("item_mgna_rt_name")
+    val itemMarginRateName: String, // 종목증거금율명
+    @SerialName("grta_rt_name")
+    val depositRateName: String, // 보증금율명
+    @SerialName("sbst_pric")
+    val substitutePrice: String, // 대용가격
+    @SerialName("stck_loan_unpr")
+    val stockLoanUnitPrice: String, // 주식대출단가
+)
+
+@Serializable
+data class AccountDetail(
+    @SerialName("dnca_tot_amt")
+    val depositAccountTotalAmount: String, // 예수금총금액
+    @SerialName("nxdy_excc_amt")
+    val nextDayExcessAmount: String, // 익일정산금액 - D+1 예수금
+    @SerialName("prvs_rcdl_excc_amt")
+    val previousRedemptionExcessAmount: String, // 가수도정산금액 - D+2 예수금
+    @SerialName("cma_evlu_amt")
+    val cmaEvaluationAmount: String, // CMA평가금액
+    @SerialName("bfdy_buy_amt")
+    val previousDayBuyAmount: String, // 전일매수금액
+    @SerialName("thdt_buy_amt")
+    val todayBuyAmount: String, // 금일매수금액
+    @SerialName("nxdy_auto_rdpt_amt")
+    val nextDayAutoRedemptionAmount: String, // 익일자동상환금액
+    @SerialName("bfdy_sll_amt")
+    val previousDaySellAmount: String, // 전일매도금액
+    @SerialName("thdt_sll_amt")
+    val todaySellAmount: String, // 금일매도금액
+    @SerialName("d2_auto_rdpt_amt")
+    val d2AutoRedemptionAmount: String, // D+2자동상환금액
+    @SerialName("bfdy_tlex_amt")
+    val previousDayTotalExpensesAmount: String, // 전일제비용금액
+    @SerialName("tot_loan_amt")
+    val totalLoanAmount: String, // 총대출금액
+    @SerialName("scts_evlu_amt")
+    val stockEvaluationAmount: String, // 유가평가금액
+    @SerialName("tot_evlu_amt")
+    val totalEvaluationAmount: String, // 총평가금액 - 유가증권 평가금액 합계금액 + D+2 예수금
+    @SerialName("nass_amt")
+    val netAssetAmount: String, // 순자산금액
+    @SerialName("fncg_gld_auto_rdpt_yn")
+    val autoRedemptionYn: String, // 융자금자동상환여부 - 보유현금에 대한 융자금만 차감여부
+            // 신용융자 매수체결 시점에서는 융자비율을 매매대금 100%로 계산 하였다가
+            // 수도결제일에 보증금에 해당하는 금액을 고객의 현금으로 충당하여 융자금을 감소시키는 업무
+    @SerialName("pchs_amt_smtl_amt")
+    val purchaseAmountSumTotalAmount: String, //매입금액합계금액 (원금)
+    @SerialName("evlu_amt_smtl_amt")
+    val evaluationAmountSumTotalAmount: String, //평가금액합계금액
+    @SerialName("evlu_pfls_smtl_amt")
+    val profitLossSumTotalAmount: String, //평가손익금액합계금액
+    @SerialName("tot_stln_slng_chgs")
+    val totalSettlementSellingCharges: String, //총대주매각대금
+    @SerialName("bfdy_tot_asst_evlu_amt")
+    val previousTotalAssetEvaluationAmount: String, //전일총자산평가금액
+    @SerialName("asst_icdc_amt")
+    val assetChangeAmount: String, // 자산증감액 (Asset Increase/Decrease Amount) - 일간 수익
+    @SerialName("asst_icdc_erng_rt")
+    val assetChangeRate: String, // 자산증감율 (Asset Increase/Decrease Earning Rate) - 데이터 미제공
+) {
+    // 총 수익률
+    fun totalProfitRate(): Double {
+        try {
+            val cost = purchaseAmountSumTotalAmount.toDouble() // 원금
+            val value = evaluationAmountSumTotalAmount.toDouble() // 평가액
+
+            if (cost == 0.0) return 0.0
+            return (value - cost) / cost * 100
+        } catch (_: NumberFormatException) {
+            return 0.0
+        }
+    }
+
+    // 전날 대비 수익률
+    fun dailyProfitRate(): Double {
+        try {
+            val profit = assetChangeAmount.toDouble()
+            // FIXME: 예수금 포함이라서 정확하지 않음
+            val cost = previousTotalAssetEvaluationAmount.toDouble() // 전일 자산
+
+            if (cost == 0.0) return 0.0
+            return profit / cost * 100
+        } catch (_: Exception) {
+            return 0.0
+        }
+    }
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.account
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,17 +9,17 @@ data class AccountResponse(
     val output1: List<AccountAsset>,
     val output2: List<AccountDetail>,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0510"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+    override val msgCd: String,
+    override val msg1: String,
 
     // 다음 연속 조회시 사용
     @SerialName("ctx_area_fk100")
     val fk100: String, // 연속조회검색조건100
     @SerialName("ctx_area_nk100")
     val nk100: String, // 연속조회키100
-)
+) : ApiResponse
 
 @Serializable
 data class AccountAsset(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/account/AccountResponse.kt
@@ -32,7 +32,7 @@ data class AccountAsset(
     @SerialName("bfdy_buy_qty")
     val prevDayBuyQuantity: String, // 전일매수수량
     @SerialName("bfdy_sll_qty")
-    val prevDaySellQuantity: String, // 금일매수수량
+    val prevDaySellQuantity: String, // 전일매도수량
     @SerialName("thdt_buyqty") // api 문서가 오타인데 실제로 값도 이렇게 옴
     val todayBuyQuantity: String, // 금일매수수량
     @SerialName("thdt_sll_qty")

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/ApprovalKey.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/ApprovalKey.kt
@@ -1,0 +1,10 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ApprovalKeyResponse(
+    @SerialName("approval_key")
+    val approvalKey: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/HashKeyRequest.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/HashKeyRequest.kt
@@ -1,0 +1,10 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HashKeyRequest(
+    @SerialName(value = "JsonBody")
+    val jsonBody: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/HashKeyResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/HashKeyResponse.kt
@@ -1,0 +1,18 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HashKeyResponse(
+    @SerialName(value = "BODY")
+    val body: HashKeyBody,
+    @SerialName(value = "HASH")
+    val hash: String,
+)
+
+@Serializable
+data class HashKeyBody(
+    @SerialName(value = "JsonBody")
+    val jsonBody: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/RevokeTokenRequest.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/RevokeTokenRequest.kt
@@ -1,0 +1,13 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RevokeTokenRequest(
+    @SerialName(value = "appkey")
+    val appKey: String,
+    @SerialName(value = "appsecret")
+    val appSecret: String,
+    val token: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/RevokeTokenResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/RevokeTokenResponse.kt
@@ -1,0 +1,13 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.Serializable
+
+/**
+ * https://apiportal.koreainvestment.com/apiservice/oauth2#L_dd3cb447-5034-4711-8c88-62c913429c7b
+ *
+ */
+@Serializable
+data class RevokeTokenResponse(
+    val code: String, // HTTP 응답코드
+    val message: String, // 응답 메시지
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/TokenRequest.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/TokenRequest.kt
@@ -1,0 +1,15 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class TokenRequest(
+    @SerialName(value = "grant_type")
+    val grantType: String,
+    @SerialName(value = "appkey")
+    val appKey: String?,
+    @SerialName(value = "appsecret")
+    val appSecret: String?,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/TokenResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/TokenResponse.kt
@@ -1,0 +1,38 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://apiportal.koreainvestment.com/apiservice/oauth2#L_fa778c98-f68d-451e-8fff-b1c6bfe5cd30
+ *
+ * access_token	접근토큰	String	Y	350	OAuth 토큰이 필요한 API 경우 발급한 Access token
+ * ex) "eyJ0eXUxMiJ9.eyJz…..................................."
+ *
+ * - 일반개인고객/일반법인고객
+ * . Access token 유효기간 1일
+ * .. 일정시간(6시간) 이내에 재호출 시에는 직전 토큰값을 리턴
+ * . OAuth 2.0의 Client Credentials Grant 절차를 준용
+ *
+ * - 제휴법인
+ * . Access token 유효기간 3개월
+ * . Refresh token 유효기간 1년
+ * . OAuth 2.0의 Authorization Code Grant 절차를 준용
+ * token_type	접근토큰유형	String	Y	20	접근토큰유형 : "Bearer"
+ * ※ API 호출 시, 접근토큰유형 "Bearer" 입력. ex) "Bearer eyJ...."
+ * expires_in	접근토큰 유효기간	Number	Y	10	유효기간(초)
+ * ex) 7776000
+ * access_token_token_expired	접근토큰 유효기간(일시표시)	String	Y	50	유효기간(년:월:일 시:분:초)
+ * ex) "2022-08-30 08:10:10"
+ */
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token")
+    val accessToken: String,
+    @SerialName("token_type")
+    val tokenType: String,
+    @SerialName("expires_in")
+    val expiresIn: Int,
+    @SerialName("access_token_token_expired")
+    val accessTokenTokenExpired: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/auth/WebSocketKeyRequest.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/auth/WebSocketKeyRequest.kt
@@ -1,0 +1,19 @@
+package com.trueedu.spac.api.model.dto.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+/**
+ * TokenRequest 와 데이터가 같지만
+ * 어의 없게도 appsecret 대신 secretkey 로 보내야 함
+ */
+@Serializable
+data class WebSocketKeyRequest(
+    @SerialName(value = "grant_type")
+    val grantType: String,
+    @SerialName(value = "appkey")
+    val appKey: String,
+    @SerialName(value = "secretkey")
+    val secretKey: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/common/ApiResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/common/ApiResponse.kt
@@ -27,11 +27,23 @@ interface ApiResponse {
     /**
      * API 호출 성공 여부
      */
-    fun isSuccess(): Boolean = rtCd == "0"
+    fun isSuccess(): Boolean = rtCd == RT_CD_SUCCESS
 
     /**
      * API 호출 실패 여부
      */
     fun isFailure(): Boolean = !isSuccess()
+
+    companion object {
+        /**
+         * 응답 성공 코드
+         */
+        const val RT_CD_SUCCESS = "0"
+
+        /**
+         * 응답 실패 코드
+         */
+        const val RT_CD_FAILURE = "1"
+    }
 }
 

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/common/ApiResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/common/ApiResponse.kt
@@ -1,0 +1,37 @@
+package com.trueedu.spac.api.model.dto.common
+
+/**
+ * 한국투자증권 API 공통 응답 인터페이스
+ */
+interface ApiResponse {
+    /**
+     * 성공 실패 여부
+     * "0": 성공
+     * "1": 실패
+     */
+    val rtCd: String
+
+    /**
+     * 응답 코드
+     * 예: "MCA00000", "KIOK0560" 등
+     */
+    val msgCd: String
+
+    /**
+     * 응답 메시지
+     * 예: "정상처리 되었습니다."
+     * 일부 API는 이 필드를 사용하지 않을 수 있습니다.
+     */
+    val msg1: String?
+
+    /**
+     * API 호출 성공 여부
+     */
+    fun isSuccess(): Boolean = rtCd == "0"
+
+    /**
+     * API 호출 실패 여부
+     */
+    fun isFailure(): Boolean = !isSuccess()
+}
+

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/AppNotice.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/AppNotice.kt
@@ -1,0 +1,15 @@
+package com.trueedu.spac.api.model.dto.firebase
+
+data class AppNotice(
+    val id: Int,
+    val title: String,
+    val body: String,
+    val cancellable: Boolean,
+) {
+    // No-argument constructor required for Firebase
+    constructor() : this(0, "", "", true)
+
+    fun available(): Boolean {
+        return id > 0 && title.isNotEmpty() && body.isNotEmpty()
+    }
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/SpacSchedule.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/SpacSchedule.kt
@@ -1,0 +1,9 @@
+package com.trueedu.spac.api.model.dto.firebase
+
+data class SpacSchedule(
+    val nameKr: String,
+    val note: String,
+) {
+    // No-argument constructor required for Firebase
+    constructor() : this("", "")
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/SpacStatus.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/SpacStatus.kt
@@ -1,0 +1,11 @@
+package com.trueedu.spac.api.model.dto.firebase
+
+data class SpacStatus(
+    val code: String,
+    val nameKr: String,
+    val redemptionPrice: Int?,
+    val status: String,
+) {
+    // No-argument constructor required for Firebase
+    constructor() : this("000000", "", null, "")
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/StockInfo.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/StockInfo.kt
@@ -1,0 +1,216 @@
+package com.trueedu.spac.api.model.dto.firebase
+
+abstract class StockInfo(
+    val code: String,
+    val nameKr: String,
+    val attributes: String,
+) {
+    abstract fun getAttribute(key: String): String?
+    abstract fun kospi(): Boolean
+    abstract fun kosdaq(): Boolean
+
+    abstract fun spac(): Boolean
+    abstract fun halt(): Boolean
+    abstract fun designated(): Boolean
+    abstract fun parValue(): String?
+    abstract fun listingDate(): String?
+    abstract fun listingShares(): String?
+
+    abstract fun prevPrice(): String?
+    abstract fun prevVolume(): String?
+    abstract fun marketCap(): String? // 전일 기준 시총
+    abstract fun sales(): String?
+    abstract fun operatingProfit(): String?
+    abstract fun shortSellingOverheating(): Boolean // 공매도과열
+    abstract fun unusualPriceSurge(): Boolean // 이상급등
+}
+
+/**
+ * 데이터 형식 참고
+ * kospi:
+ * https://github.com/koreainvestment/open-trading-api/blob/main/stocks_info/kis_kospi_code_mst.py
+ */
+class StockInfoKospi(
+    code: String,
+    nameKr: String,
+    attributes: String,
+): StockInfo(code, nameKr, attributes) {
+
+    companion object {
+        fun from(str: String): StockInfoKospi {
+            val code = str.substring(0, 9).trim()
+            val nameKr = str.substring(21, str.length - ATTRIBUTES_LEN).trim()
+            val attributes = str.takeLast(ATTRIBUTES_LEN)
+
+            return StockInfoKospi(code, nameKr, attributes)
+        }
+
+        private const val ATTRIBUTES_LEN = 227 // 예제에서는 228 이지만 실제로 해보면 하나 적음
+
+        // for kospi attributes
+        val fieldSpecs = listOf(
+            0,
+            2, 3, 7, 11, 15,
+            16, 17, 18, 19, 20,
+            21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30,
+            31, 32, 33, 34, 35,
+            36, 37, 38, 39, 40,
+            41, 50, 55, 60, 61,
+            62, 63, 65, 66, 67,
+            68, 70, 72, 74, 77,
+            78, 81, 93, 105, 113,
+            128, 149, 151, 158, 159,
+            160, 161, 162, 163, 172,
+            181, 190, 195, 204, 212,
+            221, 224, 225, 226, 227
+        )
+
+        private val columns = listOf(
+            "그룹코드", "시가총액규모", "지수업종대분류", "지수업종중분류", "지수업종소분류",
+            "제조업", "저유동성", "지배구조지수종목", "KOSPI200섹터업종", "KOSPI100",
+            "KOSPI50", "KRX", "ETP", "ELW발행", "KRX100",
+            "KRX자동차", "KRX반도체", "KRX바이오", "KRX은행", "SPAC",
+            "KRX에너지화학", "KRX철강", "단기과열", "KRX미디어통신", "KRX건설",
+            "Non1", "KRX증권", "KRX선박", "KRX섹터_보험", "KRX섹터_운송",
+            "SRI", "기준가", "매매수량단위", "시간외수량단위", "거래정지",
+            "정리매매", "관리종목", "시장경고", "경고예고", "불성실공시",
+            "우회상장", "락구분", "액면변경", "증자구분", "증거금비율",
+            "신용가능", "신용기간", "전일거래량", "액면가", "상장일자",
+            "상장주수", "자본금", "결산월", "공모가", "우선주",
+            "공매도과열", "이상급등", "KRX300", "KOSPI", "매출액",
+            "영업이익", "경상이익", "당기순이익", "ROE", "기준년월",
+            "시가총액", "그룹사코드", "회사신용한도초과", "담보대출가능", "대주가능"
+        )
+            .mapIndexed { index, s -> s to index }
+            .toMap()
+    }
+
+    // No-argument constructor required for Firebase
+    constructor() : this("000000", "", "")
+
+    override fun spac() = getAttribute("SPAC") == "Y"
+    override fun halt() = getAttribute("거래정지") == "Y"
+    override fun designated() = getAttribute("관리종목") == "Y"
+    override fun parValue() = getAttribute("액면가")
+    override fun listingDate() = getAttribute("상장일자")
+    override fun listingShares() = getAttribute("상장주수")
+
+    override fun prevPrice() = getAttribute("기준가")
+    override fun prevVolume() = getAttribute("전일거래량")
+    override fun marketCap() = getAttribute("시가총액")?.dropWhile { it == '0' } // 전일 기준
+    override fun sales() = getAttribute("매출액")
+    override fun operatingProfit() = getAttribute("영업이익")
+    override fun shortSellingOverheating() = getAttribute("공매도과열") == "Y"
+    override fun unusualPriceSurge() = getAttribute("이상급등") == "Y"
+
+    fun kospi100() = getAttribute("KOSPI100")
+    fun kospi50() = getAttribute("KOSPI50")
+    fun capitalStock() = getAttribute("자본금")
+
+
+    // stock attributes
+    override fun getAttribute(key: String): String? {
+        return columns[key]?.let { index ->
+            return attributes.substring(fieldSpecs[index], fieldSpecs[index + 1])
+        }
+    }
+
+    override fun kospi() = true
+    override fun kosdaq() = false
+}
+
+/**
+ * 데이터 형식 참고
+ * kosdaq:
+ * https://github.com/koreainvestment/open-trading-api/blob/main/stocks_info/kis_kosdaq_code_mst.py
+ */
+class StockInfoKosdaq(
+    code: String,
+    nameKr: String,
+    attributes: String,
+): StockInfo(code, nameKr, attributes) {
+
+    companion object {
+        fun from(str: String): StockInfoKosdaq {
+            val code = str.substring(0, 9).trim()
+            val nameKr = str.substring(21, str.length - ATTRIBUTES_LEN).trim()
+            val attributes = str.takeLast(ATTRIBUTES_LEN)
+
+            return StockInfoKosdaq(code, nameKr, attributes)
+        }
+
+        private const val ATTRIBUTES_LEN = 221 // 예제에서는 222 이지만 실제로 해보면 하나 적음
+
+        val fieldSpecs = listOf(
+            0,
+            2, 3, 7, 11, 15,
+            16, 17, 18, 19, 20,
+            21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30,
+            31, 32, 33, 34, 35,
+            36, 45, 50, 55, 56,
+            57, 58, 60, 61, 62,
+            63, 65, 67, 69, 72,
+            73, 76, 88, 100, 108,
+            123, 144, 146, 153, 154,
+            155, 156, 157, 166, 175,
+            184, 189, 198, 206, 215,
+            218, 219, 220, 221
+        )
+
+        /**
+         * 혼란을 방지하기 위해 예제 코드의 텍스트를 그대로 옮김
+         */
+        val columns = listOf(
+            "증권그룹구분코드", "시가총액 규모 구분 코드 유가", "지수업종 대분류 코드", "지수 업종 중분류 코드", "지수업종 소분류 코드",
+            "벤처기업 여부 (Y/N)", "저유동성종목 여부", "KRX 종목 여부", "ETP 상품구분코드", "KRX100 종목 여부 (Y/N)",
+            "KRX 자동차 여부", "KRX 반도체 여부", "KRX 바이오 여부", "KRX 은행 여부", "기업인수목적회사여부",
+            "KRX 에너지 화학 여부", "KRX 철강 여부", "단기과열종목구분코드", "KRX 미디어 통신 여부", "KRX 건설 여부",
+            "(코스닥)투자주의환기종목여부", "KRX 증권 구분", "KRX 선박 구분", "KRX섹터지수 보험여부", "KRX섹터지수 운송여부",
+            "KOSDAQ150지수여부 (Y,N)", "주식 기준가", "정규 시장 매매 수량 단위", "시간외 시장 매매 수량 단위", "거래정지 여부",
+            "정리매매 여부", "관리 종목 여부", "시장 경고 구분 코드", "시장 경고위험 예고 여부", "불성실 공시 여부",
+            "우회 상장 여부", "락구분 코드", "액면가 변경 구분 코드", "증자 구분 코드", "증거금 비율",
+            "신용주문 가능 여부", "신용기간", "전일 거래량", "주식 액면가", "주식 상장 일자",
+            "상장 주수(천)", "자본금", "결산 월", "공모 가격", "우선주 구분 코드",
+            "공매도과열종목여부", "이상급등종목여부", "KRX300 종목 여부 (Y/N)", "매출액", "영업이익",
+            "경상이익", "단기순이익", "ROE(자기자본이익률)", "기준년월", "전일기준 시가총액 (억)",
+            "그룹사 코드", "회사신용한도초과여부", "담보대출가능여부", "대주가능여부"
+        )
+            .mapIndexed { index, s -> s to index }
+            .toMap()
+    }
+
+    // No-argument constructor required for Firebase
+    constructor() : this("000000", "", "")
+
+    // stock attributes
+    override fun getAttribute(key: String): String? {
+        return columns[key]?.let { index ->
+            return attributes.substring(fieldSpecs[index], fieldSpecs[index + 1])
+        }
+    }
+
+    fun kosdaq150() = getAttribute("KOSDAQ150지수여부 (Y,N)")
+
+    override fun spac() = nameKr.contains("스팩")
+    override fun halt() = getAttribute("거래정지 여부") == "Y"
+    override fun designated() = getAttribute("관리 종목 여부") == "Y"
+    override fun parValue() = getAttribute("주식 액면가")
+    override fun listingDate() = getAttribute("주식 상장 일자")
+    override fun listingShares() = getAttribute("상장 주수(천)")
+
+    override fun prevPrice() = getAttribute("주식 기준가")
+    override fun prevVolume() = getAttribute("전일 거래량")
+    override fun marketCap() = getAttribute("전일기준 시가총액 (억)")?.dropWhile { it == '0' }
+    override fun sales() = getAttribute("매출액")
+    override fun operatingProfit() = getAttribute("영업이익")
+
+    override fun shortSellingOverheating() = getAttribute("공매도과열종목여부") == "Y"
+    override fun unusualPriceSurge() = getAttribute("이상급등종목여부") == "Y"
+
+
+
+    override fun kospi() = false
+    override fun kosdaq() = true
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/StockInfo.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/StockInfo.kt
@@ -3,26 +3,54 @@ package com.trueedu.spac.api.model.dto.firebase
 abstract class StockInfo(
     val code: String,
     val nameKr: String,
-    val attributes: String,
+    protected val attributes: String,
 ) {
-    abstract fun getAttribute(key: String): String?
-    abstract fun kospi(): Boolean
-    abstract fun kosdaq(): Boolean
+    protected abstract fun getAttribute(key: String): String?
 
-    abstract fun spac(): Boolean
-    abstract fun halt(): Boolean
-    abstract fun designated(): Boolean
-    abstract fun parValue(): String?
-    abstract fun listingDate(): String?
-    abstract fun listingShares(): String?
+    /** KOSPI 여부 */
+    abstract val isKospi: Boolean
 
-    abstract fun prevPrice(): String?
-    abstract fun prevVolume(): String?
-    abstract fun marketCap(): String? // 전일 기준 시총
-    abstract fun sales(): String?
-    abstract fun operatingProfit(): String?
-    abstract fun shortSellingOverheating(): Boolean // 공매도과열
-    abstract fun unusualPriceSurge(): Boolean // 이상급등
+    /** KOSDAQ 여부 */
+    abstract val isKosdaq: Boolean
+
+    /** SPAC 여부 */
+    abstract val isSpac: Boolean
+
+    /** 거래정지 여부 */
+    abstract val isHalt: Boolean
+
+    /** 관리종목 여부 */
+    abstract val isDesignated: Boolean
+
+    /** 액면가 */
+    abstract val parValue: String?
+
+    /** 상장일자 */
+    abstract val listingDate: String?
+
+    /** 상장주수 */
+    abstract val listingShares: String?
+
+    /** 전일 종가 */
+    abstract val prevPrice: String?
+
+    /** 전일 거래량 */
+    abstract val prevVolume: String?
+
+    /** 시가총액 (전일 기준) */
+    abstract val marketCap: String?
+
+    /** 매출액 */
+    abstract val sales: String?
+
+    /** 영업이익 */
+    abstract val operatingProfit: String?
+
+    /** 공매도과열 여부 */
+    abstract val isShortSellingOverheating: Boolean
+
+    /** 이상급등 여부 */
+    abstract val isUnusualPriceSurge: Boolean
 }
 
 /**
@@ -89,25 +117,59 @@ class StockInfoKospi(
     // No-argument constructor required for Firebase
     constructor() : this("000000", "", "")
 
-    override fun spac() = getAttribute("SPAC") == "Y"
-    override fun halt() = getAttribute("거래정지") == "Y"
-    override fun designated() = getAttribute("관리종목") == "Y"
-    override fun parValue() = getAttribute("액면가")
-    override fun listingDate() = getAttribute("상장일자")
-    override fun listingShares() = getAttribute("상장주수")
+    override val isKospi: Boolean = true
+    override val isKosdaq: Boolean = false
 
-    override fun prevPrice() = getAttribute("기준가")
-    override fun prevVolume() = getAttribute("전일거래량")
-    override fun marketCap() = getAttribute("시가총액")?.dropWhile { it == '0' } // 전일 기준
-    override fun sales() = getAttribute("매출액")
-    override fun operatingProfit() = getAttribute("영업이익")
-    override fun shortSellingOverheating() = getAttribute("공매도과열") == "Y"
-    override fun unusualPriceSurge() = getAttribute("이상급등") == "Y"
+    override val isSpac: Boolean
+        get() = getAttribute("SPAC") == "Y"
 
-    fun kospi100() = getAttribute("KOSPI100")
-    fun kospi50() = getAttribute("KOSPI50")
-    fun capitalStock() = getAttribute("자본금")
+    override val isHalt: Boolean
+        get() = getAttribute("거래정지") == "Y"
 
+    override val isDesignated: Boolean
+        get() = getAttribute("관리종목") == "Y"
+
+    override val parValue: String?
+        get() = getAttribute("액면가")
+
+    override val listingDate: String?
+        get() = getAttribute("상장일자")
+
+    override val listingShares: String?
+        get() = getAttribute("상장주수")
+
+    override val prevPrice: String?
+        get() = getAttribute("기준가")
+
+    override val prevVolume: String?
+        get() = getAttribute("전일거래량")
+
+    override val marketCap: String?
+        get() = getAttribute("시가총액")?.dropWhile { it == '0' } // 전일 기준
+
+    override val sales: String?
+        get() = getAttribute("매출액")
+
+    override val operatingProfit: String?
+        get() = getAttribute("영업이익")
+
+    override val isShortSellingOverheating: Boolean
+        get() = getAttribute("공매도과열") == "Y"
+
+    override val isUnusualPriceSurge: Boolean
+        get() = getAttribute("이상급등") == "Y"
+
+    /** KOSPI100 종목 여부 */
+    val isKospi100: Boolean
+        get() = getAttribute("KOSPI100") == "Y"
+
+    /** KOSPI50 종목 여부 */
+    val isKospi50: Boolean
+        get() = getAttribute("KOSPI50") == "Y"
+
+    /** 자본금 */
+    val capitalStock: String?
+        get() = getAttribute("자본금")
 
     // stock attributes
     override fun getAttribute(key: String): String? {
@@ -115,9 +177,6 @@ class StockInfoKospi(
             return attributes.substring(fieldSpecs[index], fieldSpecs[index + 1])
         }
     }
-
-    override fun kospi() = true
-    override fun kosdaq() = false
 }
 
 /**
@@ -184,33 +243,56 @@ class StockInfoKosdaq(
     // No-argument constructor required for Firebase
     constructor() : this("000000", "", "")
 
+    override val isKospi: Boolean = false
+    override val isKosdaq: Boolean = true
+
+    override val isSpac: Boolean
+        get() = nameKr.contains("스팩")
+
+    override val isHalt: Boolean
+        get() = getAttribute("거래정지 여부") == "Y"
+
+    override val isDesignated: Boolean
+        get() = getAttribute("관리 종목 여부") == "Y"
+
+    override val parValue: String?
+        get() = getAttribute("주식 액면가")
+
+    override val listingDate: String?
+        get() = getAttribute("주식 상장 일자")
+
+    override val listingShares: String?
+        get() = getAttribute("상장 주수(천)")
+
+    override val prevPrice: String?
+        get() = getAttribute("주식 기준가")
+
+    override val prevVolume: String?
+        get() = getAttribute("전일 거래량")
+
+    override val marketCap: String?
+        get() = getAttribute("전일기준 시가총액 (억)")?.dropWhile { it == '0' }
+
+    override val sales: String?
+        get() = getAttribute("매출액")
+
+    override val operatingProfit: String?
+        get() = getAttribute("영업이익")
+
+    override val isShortSellingOverheating: Boolean
+        get() = getAttribute("공매도과열종목여부") == "Y"
+
+    override val isUnusualPriceSurge: Boolean
+        get() = getAttribute("이상급등종목여부") == "Y"
+
+    /** KOSDAQ150 종목 여부 */
+    val isKosdaq150: Boolean
+        get() = getAttribute("KOSDAQ150지수여부 (Y,N)") == "Y"
+
     // stock attributes
     override fun getAttribute(key: String): String? {
         return columns[key]?.let { index ->
             return attributes.substring(fieldSpecs[index], fieldSpecs[index + 1])
         }
     }
-
-    fun kosdaq150() = getAttribute("KOSDAQ150지수여부 (Y,N)")
-
-    override fun spac() = nameKr.contains("스팩")
-    override fun halt() = getAttribute("거래정지 여부") == "Y"
-    override fun designated() = getAttribute("관리 종목 여부") == "Y"
-    override fun parValue() = getAttribute("주식 액면가")
-    override fun listingDate() = getAttribute("주식 상장 일자")
-    override fun listingShares() = getAttribute("상장 주수(천)")
-
-    override fun prevPrice() = getAttribute("주식 기준가")
-    override fun prevVolume() = getAttribute("전일 거래량")
-    override fun marketCap() = getAttribute("전일기준 시가총액 (억)")?.dropWhile { it == '0' }
-    override fun sales() = getAttribute("매출액")
-    override fun operatingProfit() = getAttribute("영업이익")
-
-    override fun shortSellingOverheating() = getAttribute("공매도과열종목여부") == "Y"
-    override fun unusualPriceSurge() = getAttribute("이상급등종목여부") == "Y"
-
-
-
-    override fun kospi() = false
-    override fun kosdaq() = true
 }

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/UserAsset.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/UserAsset.kt
@@ -1,0 +1,15 @@
+package com.trueedu.spac.api.model.dto.firebase
+
+/**
+ * firebase database 에 보유 자산을 저장하기 위한 DTO
+ */
+data class UserAsset(
+    val code: String,
+    val nameKr: String,
+    val price: Double,
+    val quantity: Double,
+    val memo: String,
+) {
+    // No-argument constructor required for Firebase
+    constructor() : this("000000", "", 0.0, 0.0, "")
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
@@ -1,0 +1,25 @@
+package com.trueedu.spac.api.model.dto.order
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrderModifyResponse(
+    @SerialName("output")
+    val orderModifyDetail: OrderModifyDetail?,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg: String?, // 응답메세지 - "정상처리 되었습니다."
+    val msg1: String?,
+)
+
+@Serializable
+data class OrderModifyDetail(
+    // -KRX_FWDG_ORD_ORGNO	한국거래소전송주문조직번호	String	Y	5	주문시 한국투자증권 시스템에서 지정된 영업점코드
+    @SerialName("ODNO")
+    val orderNo: String, // 정정 주문시 한국투자증권 시스템에서 채번된 주문번호
+    @SerialName("ORD_TMD")
+    val orderTime: String, // 주문시각(시분초HHMMSS)
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
@@ -18,9 +18,8 @@ data class OrderModifyResponse(
 
 @Serializable
 data class OrderModifyDetail(
-    // -KRX_FWDG_ORD_ORGNO	한국거래소전송주문조직번호	String	Y	5	주문시 한국투자증권 시스템에서 지정된 영업점코드
     @SerialName("ODNO")
     val orderNo: String, // 정정 주문시 한국투자증권 시스템에서 채번된 주문번호
     @SerialName("ORD_TMD")
-    val orderTime: String, // 주문시각(시분초HHMMSS)
+    val orderTime: String, // 주문시각 (HHmmss)
 )

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderModifyResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.order
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,12 +9,12 @@ data class OrderModifyResponse(
     @SerialName("output")
     val orderModifyDetail: OrderModifyDetail?,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg: String?, // 응답메세지 - "정상처리 되었습니다."
-    val msg1: String?,
-)
+    override val msgCd: String,
+    override val msg1: String?,
+    val msg: String?,
+) : ApiResponse
 
 @Serializable
 data class OrderModifyDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderResponse.kt
@@ -1,0 +1,25 @@
+package com.trueedu.spac.api.model.dto.order
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrderResponse(
+    @SerialName("output")
+    val orderDetail: OrderDetail?,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg: String?, // 응답메세지 - "정상처리 되었습니다."
+    val msg1: String?,
+)
+@Serializable
+data class OrderDetail(
+    @SerialName("KRX_FWDG_ORD_ORGNO")
+    val krxForwardingOrderOrgNumber: String, // 한국거래소전송주문조직번호
+    @SerialName("ODNO")
+    val orderNumber: String, // 주문번호
+    @SerialName("ORD_TMD")
+    val orderTime: String, // 주문시각(HHmmss)
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/OrderResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.order
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,12 +9,12 @@ data class OrderResponse(
     @SerialName("output")
     val orderDetail: OrderDetail?,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg: String?, // 응답메세지 - "정상처리 되었습니다."
-    val msg1: String?,
-)
+    override val msgCd: String,
+    override val msg1: String?,
+    val msg: String?,
+) : ApiResponse
 @Serializable
 data class OrderDetail(
     @SerialName("KRX_FWDG_ORD_ORGNO")

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
@@ -1,0 +1,22 @@
+package com.trueedu.spac.api.model.dto.order
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ScheduleOrderCancelResponse(
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0560"
+    val msg: String?, // 응답메세지
+    val msg1: String?, // 응답메세지 - 문서와는 달리 msg1 필드로 성공 또는 실패 메시지가 오고 있음
+    val output: ResponseResult?,
+)
+
+@Serializable
+data class ResponseResult(
+    // 문서에는 소문자로 되어 있지만, 실제로 대문자로 오고 있음
+    @SerialName("NRML_PRCS_YN")
+    val result: String, // Y or N
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
@@ -1,18 +1,19 @@
 package com.trueedu.spac.api.model.dto.order
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ScheduleOrderCancelResponse(
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0560"
-    val msg: String?, // 응답메세지
-    val msg1: String?, // 응답메세지 - 문서와는 달리 msg1 필드로 성공 또는 실패 메시지가 오고 있음
+    override val msgCd: String,
+    override val msg1: String?,
+    val msg: String?,
     val output: ResponseResult?,
-)
+) : ApiResponse
 
 @Serializable
 data class ResponseResult(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderCancelResponse.kt
@@ -20,4 +20,21 @@ data class ResponseResult(
     // 문서에는 소문자로 되어 있지만, 실제로 대문자로 오고 있음
     @SerialName("NRML_PRCS_YN")
     val result: String, // Y or N
-)
+) {
+    /**
+     * 정상 처리 여부
+     */
+    fun isSuccess() = result == YES
+
+    companion object {
+        /**
+         * 정상 처리
+         */
+        const val YES = "Y"
+
+        /**
+         * 실패
+         */
+        const val NO = "N"
+    }
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResponse.kt
@@ -1,0 +1,21 @@
+package com.trueedu.spac.api.model.dto.order
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ScheduleOrderResponse(
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0560"
+    @SerialName("msg1")
+    val msg: String?, // 응답메세지
+    val output: ScheduleOrderSeq?,
+)
+
+@Serializable
+data class ScheduleOrderSeq(
+    @SerialName("RSVN_ORD_SEQ")
+    val rsvnOrdSeq: String, // 예약주문번호
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResponse.kt
@@ -1,18 +1,19 @@
 package com.trueedu.spac.api.model.dto.order
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ScheduleOrderResponse(
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0560"
+    override val msgCd: String,
     @SerialName("msg1")
-    val msg: String?, // 응답메세지
+    override val msg1: String?,
     val output: ScheduleOrderSeq?,
-)
+) : ApiResponse
 
 @Serializable
 data class ScheduleOrderSeq(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
@@ -69,6 +69,15 @@ data class ScheduleOrderResultDetail(
     @SerialName("rsvn_end_dt")
     val endDate: String, // 예약종료일자
 ) {
-    // '처리' 상태인 예약은 삭제, 수정 불가
-    fun disabled() = processResult == "처리"
+    /**
+     * '처리' 상태인 예약은 삭제, 수정 불가
+     */
+    fun disabled() = processResult == PROCESS_RESULT_PROCESSED
+
+    companion object {
+        /**
+         * 처리 완료 상태
+         */
+        const val PROCESS_RESULT_PROCESSED = "처리"
+    }
 }

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
@@ -40,8 +40,6 @@ data class ScheduleOrderResultDetail(
     val cancelOrderDate: String, // 취소주문일자
     @SerialName("ord_tmd")
     val orderTime: String, // 주문시각
-    // -ctac_tlno	연락전화번호	String	N	20
-
     @SerialName("rjct_rson2")
     val rejectReason: String, // 거부사유2
     @SerialName("odno")
@@ -56,16 +54,12 @@ data class ScheduleOrderResultDetail(
     val price: String, // 주문예약단가
     @SerialName("tot_ccld_amt")
     val totalClearedAmount: String, // 총체결금액
-    // @SerialName("loan_dt")
-    // loan_dt	대출일자	String	N	8
     @SerialName("cncl_rcit_tmd")
     val cancelReceivedTime: String, // 취소접수시각
     @SerialName("prcs_rslt")
     val processResult: String, // 처리결과
     @SerialName("ord_dvsn_name")
     val orderDivisionName: String, // 주문구분명
-    // @SerialName("tmnl_mdia_kind_cd")
-    // val terminalMediaKindCode: String, // 단말매체종류코드
     @SerialName("rsvn_end_dt")
     val endDate: String, // 예약종료일자
 ) {

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
@@ -1,0 +1,73 @@
+package com.trueedu.spac.api.model.dto.order
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ScheduleOrderResult(
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0560"
+    @SerialName("msg1")
+    val msg: String, // 응답메세지
+    @SerialName("output")
+    val list: List<ScheduleOrderResultDetail>?,
+    @SerialName("ctx_area_fk200")
+    val fk200: String,
+    @SerialName("ctx_area_nk200")
+    val nk200: String,
+)
+
+@Serializable
+data class ScheduleOrderResultDetail(
+    @SerialName("rsvn_ord_seq")
+    val seq: String, // 예약주문 순번
+    @SerialName("rsvn_ord_ord_dt")
+    val orderDate: String, // 예약주문주문일자
+    @SerialName("rsvn_ord_rcit_dt")
+    val receivedDate: String, // 예약주문접수일자
+    @SerialName("pdno")
+    val code: String, // 상품번호
+    @SerialName("ord_dvsn_cd")
+    val orderDivisionCode: String, // 주문구분코드
+    @SerialName("ord_rsvn_qty")
+    val orderReservedQuantity: String, // 주문예약수량
+    @SerialName("tot_ccld_qty")
+    val totalClearedQuantity: String, // 총체결수량
+    @SerialName("cncl_ord_dt")
+    val cancelOrderDate: String, // 취소주문일자
+    @SerialName("ord_tmd")
+    val orderTime: String, // 주문시각
+    // -ctac_tlno	연락전화번호	String	N	20
+
+    @SerialName("rjct_rson2")
+    val rejectReason: String, // 거부사유2
+    @SerialName("odno")
+    val orderNumber: String, // 주문번호
+    @SerialName("rsvn_ord_rcit_tmd")
+    val receivedTime: String, // 예약주문접수시각
+    @SerialName("kor_item_shtn_name")
+    val nameKr: String, // 한글종목단축명
+    @SerialName("sll_buy_dvsn_cd")
+    val sellBuyDivisionCode: String, // 매도매수구분코드
+    @SerialName("ord_rsvn_unpr")
+    val price: String, // 주문예약단가
+    @SerialName("tot_ccld_amt")
+    val totalClearedAmount: String, // 총체결금액
+    // @SerialName("loan_dt")
+    // loan_dt	대출일자	String	N	8
+    @SerialName("cncl_rcit_tmd")
+    val cancelReceivedTime: String, // 취소접수시각
+    @SerialName("prcs_rslt")
+    val processResult: String, // 처리결과
+    @SerialName("ord_dvsn_name")
+    val orderDivisionName: String, // 주문구분명
+    // @SerialName("tmnl_mdia_kind_cd")
+    // val terminalMediaKindCode: String, // 단말매체종류코드
+    @SerialName("rsvn_end_dt")
+    val endDate: String, // 예약종료일자
+) {
+    // '처리' 상태인 예약은 삭제, 수정 불가
+    fun disabled() = processResult == "처리"
+}

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/order/ScheduleOrderResult.kt
@@ -1,23 +1,24 @@
 package com.trueedu.spac.api.model.dto.order
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ScheduleOrderResult(
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0560"
+    override val msgCd: String,
     @SerialName("msg1")
-    val msg: String, // 응답메세지
+    override val msg1: String,
     @SerialName("output")
     val list: List<ScheduleOrderResultDetail>?,
     @SerialName("ctx_area_fk200")
     val fk200: String,
     @SerialName("ctx_area_nk200")
     val nk200: String,
-)
+) : ApiResponse
 
 @Serializable
 data class ScheduleOrderResultDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/DailyPriceResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/DailyPriceResponse.kt
@@ -1,0 +1,104 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DailyPriceResponse(
+    @SerialName("output1")
+    val stockDetail: StockDetail?,
+    @SerialName("output2")
+    val dailyPrices: List<DailyPrice>,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+)
+
+@Serializable
+data class StockDetail(
+    @SerialName("prdy_vrss")
+    val priceChange: String, // 전일 대비
+    @SerialName("prdy_vrss_sign")
+    val priceChangeSign: String, // 전일 대비 부호
+    @SerialName("prdy_ctrt")
+    val priceChangeRate: String, // 전일 대비율
+    @SerialName("stck_prdy_clpr")
+    val previousPrice: String, // 전일 종가
+    @SerialName("acml_vol")
+    val volume: String, // 누적 거래량
+    @SerialName("acml_tr_pbmn")
+    val volumeAmount: String, // 누적 거래 대금
+    @SerialName("hts_kor_isnm")
+    val nameKr: String, // HTS 한글 종목명
+    @SerialName("stck_prpr")
+    val price: String, // 주식 현재가
+    @SerialName("stck_shrn_iscd")
+    val code: String, // 주식 단축 종목코드
+    @SerialName("prdy_vol")
+    val previousVolume: String, // 전일 거래량
+    @SerialName("stck_mxpr")
+    val maxPrice: String, // 상한가
+    @SerialName("stck_llam")
+    val minPrice: String, // 하한가
+    @SerialName("stck_oprc")
+    val `open`: String, // 시가
+    @SerialName("stck_hgpr")
+    val high: String, // 최고가
+    @SerialName("stck_lwpr")
+    val low: String, // 최저가
+    @SerialName("stck_prdy_oprc")
+    val previousOpen: String, // 전일 시가
+    @SerialName("stck_prdy_hgpr")
+    val previousHigh: String, // 전일 최고가
+    @SerialName("stck_prdy_lwpr")
+    val previousLow: String, // 전일 최저가
+    // askp	매도호가	String	Y	10	매도호가
+    // bidp	매수호가	String	Y	10	매수호가
+    // prdy_vrss_vol	전일 대비 거래량	String	Y	10	전일 대비 거래량
+    // vol_tnrt	거래량 회전율	String	Y	11	거래량 회전율
+    // stck_fcam	주식 액면가	String	Y	11	주식 액면가
+    // lstn_stcn	상장 주수	String	Y	18	상장 주수
+    // cpfn	자본금	String	Y	22	자본금
+    // hts_avls	시가총액	String	Y	18	HTS 시가총액
+    val per: String,
+    val eps: String,
+    val pbr: String,
+    // itewhol_loan_rmnd_ratem name	전체 융자 잔고 비율	String	Y	13	전체 융자 잔고 비율
+)
+
+@Serializable
+data class DailyPrice(
+    @SerialName("stck_bsop_date")
+    val date: String?, // yyyyMMdd
+    @SerialName("stck_clpr")
+    val close: String?, // 주식 종가
+    @SerialName("stck_oprc")
+    val `open`: String?, // 시가
+    @SerialName("stck_hgpr")
+    val high: String?, // 고가
+    @SerialName("stck_lwpr")
+    val low: String?, // 저가
+    @SerialName("acml_vol")
+    val volume: String?, // 누적 거래량
+    @SerialName("acml_tr_pbmn")
+    val volumeAmount: String?, // 누적 거래 대금
+    /*
+    -flng_cls_code	락 구분 코드	String	Y	2	00:해당사항없음(락이 발생안한 경우)
+    01:권리락
+    02:배당락
+    03:분배락
+    04:권배락
+    05:중간(분기)배당락
+    06:권리중간배당락
+    07:권리분기배당락
+    -prtt_rate	분할 비율	String	Y	11	분할 비율
+    -mod_yn	분할변경여부	String	Y	1	Y, N
+    -revl_issu_reas	재평가사유코드	String	Y	2	재평가사유코드
+    */
+    @SerialName("prdy_vrss_sign")
+    val changeSign: String?, // 전일 대비 부호
+    @SerialName("prdy_vrss")
+    val change: String?, // 전일 대비
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/DailyPriceResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/DailyPriceResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.price
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,11 +11,11 @@ data class DailyPriceResponse(
     @SerialName("output2")
     val dailyPrices: List<DailyPrice>,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
-)
+    override val msgCd: String,
+    override val msg1: String,
+) : ApiResponse
 
 @Serializable
 data class StockDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.price
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,19 +11,18 @@ data class OrderExecutionResponse(
     @SerialName("output2")
     val orderExecutionSummary: OrderExecutionSummary?,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0560"
-    // 응답메세지 - "정상처리 되었습니다."
+    override val msgCd: String,
+    override val msg1: String,
     val msg: String?,
-    val msg1: String?,
 
     // 다음 연속 조회시 사용
     @SerialName("ctx_area_fk100")
     val fk100: String, // 연속조회검색조건100
     @SerialName("ctx_area_nk100")
     val nk100: String, // 연속조회키100
-)
+) : ApiResponse
 
 @Serializable
 data class OrderExecutionDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
@@ -29,20 +29,18 @@ data class OrderExecutionDetail(
     @SerialName("ord_dt")
     val orderDate: String, // 주문일자
     @SerialName("ord_gno_brno")
-    val orderBranchNo: String, // 주문채번지점번호 - 주문시 한국투자증권 시스템에서 지정된 영업점코드
+    val orderBranchNo: String, // 주문시 한국투자증권 시스템에서 지정된 영업점코드
     @SerialName("odno")
-    val orderNo: String, // 주문번호 - 주문시 한국투자증권 시스템에서 채번된 주문번호, 지점별 일자별로 채번됨
-             // * 주문번호 유일조건: ord_dt(주문일자) + ord_gno_brno(주문채번지점번호) + odno(주문번호)
+    val orderNo: String, // 주문시 한국투자증권 시스템에서 채번된 주문번호 (지점별 일자별로 채번됨)
+    // * 주문번호 유일조건: ord_dt(주문일자) + ord_gno_brno(주문채번지점번호) + odno(주문번호)
     @SerialName("orgn_odno")
-    val originalOrderNo: String, // 원주문번호 - 이전 주문에 채번된 주문번호
+    val originalOrderNo: String, // 원주문번호 (이전 주문에 채번된 주문번호)
     @SerialName("ord_dvsn_name")
     val orderDivisionName: String, // 주문구분명
     @SerialName("sll_buy_dvsn_cd")
-    val sellBuyDivisionCode: String, // 매도매수구분코드 - 01 : 매도 02 : 매수
+    val sellBuyDivisionCode: String, // 매도매수구분코드 (01: 매도, 02: 매수)
     @SerialName("sll_buy_dvsn_cd_name")
-    val sellBuyCodeName: String, // 매도매수구분명 - 반대매매 인경우 "임의매도"로 표시됨
-                        // 정정취소여부가 Y이면 *이 붙음
-                        //ex) 매수취소* = 매수취소가 완료됨
+    val sellBuyCodeName: String, // 매도매수구분명 (반대매매인 경우 "임의매도"로 표시, 정정취소여부가 Y이면 *이 붙음, 예: 매수취소*)
     @SerialName("pdno")
     val code: String, // 상품번호
     @SerialName("prdt_name")
@@ -93,12 +91,11 @@ data class OrderExecutionDetail(
     @SerialName("ccld_cndt_name")
     val concludedConditionName: String, // 체결조건명
     @SerialName("infm_tmd")
-    val informationTime: String, // 통보시각 - 실전투자계좌로는 해당값이 제공되지 않습니다.
-    // -ctac_tlno	연락전화번호	String	Y	20
+    val informationTime: String, // 통보시각 (실전투자계좌로는 해당값이 제공되지 않습니다)
     @SerialName("prdt_type_cd")
-    val productTypeCode: String, // 상품유형코드 - 300 : 주식 301 : 선물옵션 302 : 채권 306 : ELS
+    val productTypeCode: String, // 상품유형코드 (300: 주식, 301: 선물옵션, 302: 채권, 306: ELS)
     @SerialName("excg_dvsn_cd")
-    val exchangeDivisionCode: String, // 거래소구분코드 - 01 : 한국증권 02 : 증권거래소 03 : 코스닥 04 : K-OTC
+    val exchangeDivisionCode: String, // 거래소구분코드 (01: 한국증권, 02: 증권거래소, 03: 코스닥, 04: K-OTC)
     // 05 : 선물거래소 06 : CME 07 : EUREX
     // 21 : 금현물
     // 51 : 홍콩 52 : 상해B 53 : 심천 54 : 홍콩거래소 55 : 미국 56 : 일본 57 : 상해A
@@ -117,5 +114,5 @@ data class OrderExecutionSummary(
     @SerialName("tot_ccld_amt")
     val totalConcludedAmount: String, // 총체결금액
     @SerialName("prsm_tlex_smtl") // presumed tax, levy, and settlement total
-    val estimatedTaxAndFee: String, // 추정제비용합계 - 해당 값은 당일 데이터에 대해서만 제공됩니다.
+    val estimatedTaxAndFee: String, // 추정제비용합계 (당일 데이터에 대해서만 제공됨)
 )

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderExecutionResponse.kt
@@ -1,0 +1,121 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrderExecutionResponse(
+    @SerialName("output1")
+    val orderExecutionDetail: List<OrderExecutionDetail>?,
+    @SerialName("output2")
+    val orderExecutionSummary: OrderExecutionSummary?,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0560"
+    // 응답메세지 - "정상처리 되었습니다."
+    val msg: String?,
+    val msg1: String?,
+
+    // 다음 연속 조회시 사용
+    @SerialName("ctx_area_fk100")
+    val fk100: String, // 연속조회검색조건100
+    @SerialName("ctx_area_nk100")
+    val nk100: String, // 연속조회키100
+)
+
+@Serializable
+data class OrderExecutionDetail(
+    @SerialName("ord_dt")
+    val orderDate: String, // 주문일자
+    @SerialName("ord_gno_brno")
+    val orderBranchNo: String, // 주문채번지점번호 - 주문시 한국투자증권 시스템에서 지정된 영업점코드
+    @SerialName("odno")
+    val orderNo: String, // 주문번호 - 주문시 한국투자증권 시스템에서 채번된 주문번호, 지점별 일자별로 채번됨
+             // * 주문번호 유일조건: ord_dt(주문일자) + ord_gno_brno(주문채번지점번호) + odno(주문번호)
+    @SerialName("orgn_odno")
+    val originalOrderNo: String, // 원주문번호 - 이전 주문에 채번된 주문번호
+    @SerialName("ord_dvsn_name")
+    val orderDivisionName: String, // 주문구분명
+    @SerialName("sll_buy_dvsn_cd")
+    val sellBuyDivisionCode: String, // 매도매수구분코드 - 01 : 매도 02 : 매수
+    @SerialName("sll_buy_dvsn_cd_name")
+    val sellBuyCodeName: String, // 매도매수구분명 - 반대매매 인경우 "임의매도"로 표시됨
+                        // 정정취소여부가 Y이면 *이 붙음
+                        //ex) 매수취소* = 매수취소가 완료됨
+    @SerialName("pdno")
+    val code: String, // 상품번호
+    @SerialName("prdt_name")
+    val nameKr: String, // 상품명
+    @SerialName("ord_qty")
+    val orderQuantity: String, // 주문수량
+    @SerialName("ord_unpr")
+    val orderUnitPrice: String, // 주문단가
+    @SerialName("ord_tmd")
+    val orderTime: String, // 주문시각
+    @SerialName("tot_ccld_qty")
+    val totalConcludedQuantity: String, // 총체결수량
+    @SerialName("avg_prvs")
+    val averagePrice: String, // 체결평균가 ( 총체결금액 / 총체결수량 )
+    @SerialName("cncl_yn")
+    val cancellationYn: String, // 취소여부
+    @SerialName("tot_ccld_amt")
+    val totalConcludedAmount: String, // 총체결금액
+    @SerialName("loan_dt")
+    val loanDate: String, // 대출일자
+    /**
+     00 : 지정가
+     01 : 시장가
+     02 : 조건부지정가
+     03 : 최유리지정가
+     04 : 최우선지정가
+     05 : 장전 시간외
+     06 : 장후 시간외
+     07 : 시간외 단일가
+     08 : 자기주식
+     09 : 자기주식S-Option
+     10 : 자기주식금전신탁
+     11 : IOC지정가 (즉시체결,잔량취소)
+     12 : FOK지정가 (즉시체결,전량취소)
+     13 : IOC시장가 (즉시체결,잔량취소)
+     14 : FOK시장가 (즉시체결,전량취소)
+     15 : IOC최유리 (즉시체결,잔량취소)
+     16 : FOK최유리 (즉시체결,전량취소)
+     */
+    @SerialName("ord_dvsn_cd")
+    val orderDivisionCode: String, // 주문구분코드
+    @SerialName("cncl_cfrm_qty")
+    val cancellationConfirmationQuantity: String, // 취소확인수량
+    @SerialName("rmn_qty")
+    val remainingQuantity: String, // 잔여수량
+    @SerialName("rjct_qty")
+    val rejectionQuantity: String, // 거부수량
+    @SerialName("ccld_cndt_name")
+    val concludedConditionName: String, // 체결조건명
+    @SerialName("infm_tmd")
+    val informationTime: String, // 통보시각 - 실전투자계좌로는 해당값이 제공되지 않습니다.
+    // -ctac_tlno	연락전화번호	String	Y	20
+    @SerialName("prdt_type_cd")
+    val productTypeCode: String, // 상품유형코드 - 300 : 주식 301 : 선물옵션 302 : 채권 306 : ELS
+    @SerialName("excg_dvsn_cd")
+    val exchangeDivisionCode: String, // 거래소구분코드 - 01 : 한국증권 02 : 증권거래소 03 : 코스닥 04 : K-OTC
+    // 05 : 선물거래소 06 : CME 07 : EUREX
+    // 21 : 금현물
+    // 51 : 홍콩 52 : 상해B 53 : 심천 54 : 홍콩거래소 55 : 미국 56 : 일본 57 : 상해A
+    // 58 : 심천A 59 : 베트남 61 : 장전시간외시장 64 : 경쟁대량매매 65 : 경매매시장
+    // 81 : 시간외단일가시장
+)
+
+@Serializable
+data class OrderExecutionSummary(
+    @SerialName("tot_ord_qty")
+    val totalOrderQuantity: String, // 총주문수량: 미체결주문수량 + 체결수량 (취소주문제외)
+    @SerialName("tot_ccld_qty")
+    val totalConcludedQuantity: String, // 총체결수량
+    @SerialName("pchs_avg_pric")
+    val purchaseAveragePrice: String, // 매입평균가
+    @SerialName("tot_ccld_amt")
+    val totalConcludedAmount: String, // 총체결금액
+    @SerialName("prsm_tlex_smtl") // presumed tax, levy, and settlement total
+    val estimatedTaxAndFee: String, // 추정제비용합계 - 해당 값은 당일 데이터에 대해서만 제공됩니다.
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
@@ -24,33 +24,33 @@ data class OrderModifiableResponse(
 @Serializable
 data class OrderModifiableDetail(
     @SerialName("ord_gno_brno")
-    val ordGnoBrno: String, // 주문채번지점번호 - 주문시 한국투자증권 시스템에서 지정된 영업점코드
+    val ordGnoBrno: String, // 주문시 한국투자증권 시스템에서 지정된 영업점코드
     @SerialName("odno")
-    val orderNo: String, // 주문번호 - 주문시 한국투자증권 시스템에서 채번된 주문번호
+    val orderNo: String, // 주문시 한국투자증권 시스템에서 채번된 주문번호
     @SerialName("orgn_odno")
-    val originalOrderNo: String, // 원주문번호 - 정정/취소주문 인경우 원주문번호
+    val originalOrderNo: String, // 원주문번호 (정정/취소주문인 경우)
     @SerialName("ord_dvsn_name")
-    val orderDivisionName: String, // 주문구분명 - 주문구분명
+    val orderDivisionName: String, // 주문구분명
     @SerialName("pdno")
     val code: String, // 종목번호(뒤 6자리만 해당)
     @SerialName("prdt_name")
-    val nameKr: String, // 상품명 - 종목명
+    val nameKr: String, // 종목명
     @SerialName("rvse_cncl_dvsn_name")
-    val revisionCancellationDivisionName : String, // 정정취소구분명 - 정정 또는 취소 여부 표시
+    val revisionCancellationDivisionName : String, // 정정취소구분명 (정정 또는 취소 여부)
     @SerialName("ord_qty")
     val quantity: String, // 주문수량
     @SerialName("ord_unpr")
     val price: String, // 주문단가
     @SerialName("ord_tmd")
-    val orderTime: String, //주문시각(시분초HHMMSS)
+    val orderTime: String, // 주문시각 (HHmmss)
     @SerialName("tot_ccld_qty")
-    val totalContractedQuantity: String, // 총체결수량 - 주문 수량 중 체결된 수량
+    val totalContractedQuantity: String, // 총체결수량 (주문 수량 중 체결된 수량)
     @SerialName("tot_ccld_amt")
-    val totalContractedAmount: String, // 총체결금액 -	주문금액 중 체결금액
+    val totalContractedAmount: String, // 총체결금액 (주문금액 중 체결금액)
     @SerialName("psbl_qty")
-    val possibleQuantity: String, // 가능수량 - 정정/취소 주문 가능 수량
+    val possibleQuantity: String, // 가능수량 (정정/취소 주문 가능 수량)
     @SerialName("sll_buy_dvsn_cd")
-    val sellBuyDivisionCode: String, // 매도매수구분코드 - 01 : 매도 02 : 매수
+    val sellBuyDivisionCode: String, // 매도매수구분코드 (01: 매도, 02: 매수)
     /*
     00 : 지정가
     01 : 시장가
@@ -72,7 +72,5 @@ data class OrderModifiableDetail(
     51 : 장중대량
     */
     @SerialName("ord_dvsn_cd")
-    val orderDivisionCode: String, // 주문구분코드 - 주문구분코드
-
-// -mgco_aptm_odno	운용사지정주문번호	String	Y	12	주문 번호 (운용사 통한 주문)
+    val orderDivisionCode: String, // 주문구분코드
 )

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
@@ -1,0 +1,77 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrderModifiableResponse(
+    @SerialName("output")
+    val orderModifiableDetail: List<OrderModifiableDetail>,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "KIOK0560"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+
+    // 다음 연속 조회시 사용
+    @SerialName("ctx_area_fk100")
+    val fk100: String, // 연속조회검색조건100
+    @SerialName("ctx_area_nk100")
+    val nk100: String, // 연속조회키100
+)
+
+@Serializable
+data class OrderModifiableDetail(
+    @SerialName("ord_gno_brno")
+    val ordGnoBrno: String, // 주문채번지점번호 - 주문시 한국투자증권 시스템에서 지정된 영업점코드
+    @SerialName("odno")
+    val orderNo: String, // 주문번호 - 주문시 한국투자증권 시스템에서 채번된 주문번호
+    @SerialName("orgn_odno")
+    val originalOrderNo: String, // 원주문번호 - 정정/취소주문 인경우 원주문번호
+    @SerialName("ord_dvsn_name")
+    val orderDivisionName: String, // 주문구분명 - 주문구분명
+    @SerialName("pdno")
+    val code: String, // 종목번호(뒤 6자리만 해당)
+    @SerialName("prdt_name")
+    val nameKr: String, // 상품명 - 종목명
+    @SerialName("rvse_cncl_dvsn_name")
+    val revisionCancellationDivisionName : String, // 정정취소구분명 - 정정 또는 취소 여부 표시
+    @SerialName("ord_qty")
+    val quantity: String, // 주문수량
+    @SerialName("ord_unpr")
+    val price: String, // 주문단가
+    @SerialName("ord_tmd")
+    val orderTime: String, //주문시각(시분초HHMMSS)
+    @SerialName("tot_ccld_qty")
+    val totalContractedQuantity: String, // 총체결수량 - 주문 수량 중 체결된 수량
+    @SerialName("tot_ccld_amt")
+    val totalContractedAmount: String, // 총체결금액 -	주문금액 중 체결금액
+    @SerialName("psbl_qty")
+    val possibleQuantity: String, // 가능수량 - 정정/취소 주문 가능 수량
+    @SerialName("sll_buy_dvsn_cd")
+    val sellBuyDivisionCode: String, // 매도매수구분코드 - 01 : 매도 02 : 매수
+    /*
+    00 : 지정가
+    01 : 시장가
+    02 : 조건부지정가
+    03 : 최유리지정가
+    04 : 최우선지정가
+    05 : 장전 시간외
+    06 : 장후 시간외
+    07 : 시간외 단일가
+    08 : 자기주식
+    09 : 자기주식S-Option
+    10 : 자기주식금전신탁
+    11 : IOC지정가 (즉시체결,잔량취소)
+    12 : FOK지정가 (즉시체결,전량취소)
+    13 : IOC시장가 (즉시체결,잔량취소)
+    14 : FOK시장가 (즉시체결,전량취소)
+    15 : IOC최유리 (즉시체결,잔량취소)
+    16 : FOK최유리 (즉시체결,전량취소)
+    51 : 장중대량
+    */
+    @SerialName("ord_dvsn_cd")
+    val orderDivisionCode: String, // 주문구분코드 - 주문구분코드
+
+// -mgco_aptm_odno	운용사지정주문번호	String	Y	12	주문 번호 (운용사 통한 주문)
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/OrderModifiableResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.price
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,17 +9,17 @@ data class OrderModifiableResponse(
     @SerialName("output")
     val orderModifiableDetail: List<OrderModifiableDetail>,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "KIOK0560"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+    override val msgCd: String,
+    override val msg1: String,
 
     // 다음 연속 조회시 사용
     @SerialName("ctx_area_fk100")
     val fk100: String, // 연속조회검색조건100
     @SerialName("ctx_area_nk100")
     val nk100: String, // 연속조회키100
-)
+) : ApiResponse
 
 @Serializable
 data class OrderModifiableDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceChangeSign.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceChangeSign.kt
@@ -1,0 +1,42 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * 전일 대비 부호
+ */
+enum class PriceChangeSign(val code: String, val description: String) {
+    UPPER_LIMIT("1", "상한"),
+    RISE("2", "상승"),
+    UNCHANGED("3", "보합"),
+    LOWER_LIMIT("4", "하한"),
+    FALL("5", "하락"),
+    UNKNOWN("0", "알 수 없음");
+
+    companion object {
+        fun from(code: String): PriceChangeSign {
+            return entries.find { it.code == code } ?: UNKNOWN
+        }
+    }
+
+    fun isPositive() = this == UPPER_LIMIT || this == RISE
+    fun isNegative() = this == LOWER_LIMIT || this == FALL
+    fun isUnchanged() = this == UNCHANGED
+}
+
+object PriceChangeSignSerializer : KSerializer<PriceChangeSign> {
+    override val descriptor = PrimitiveSerialDescriptor("PriceChangeSign", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: PriceChangeSign) {
+        encoder.encodeString(value.code)
+    }
+
+    override fun deserialize(decoder: Decoder): PriceChangeSign {
+        return PriceChangeSign.from(decoder.decodeString())
+    }
+}
+

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
@@ -16,14 +16,13 @@ data class PriceResponse(
 @Serializable
 data class PriceDetail(
     @SerialName("iscd_stat_cls_code")
-    val stockState: String, // 00 : 그외 51 : 관리종목 52 : 투자위험 53 : 투자경고 54 : 투자주의 55 : 신용가능
-                            // 57 : 증거금 100% 58 : 거래정지 59 : 단기과열
+    @Serializable(with = StockStateSerializer::class)
+    val stockState: StockState, // 종목 상태 코드
     @SerialName("marg_rate")
     val marginRate: String, // 증거금 비율
 
     @SerialName("rprs_mrkt_kor_name")
-    val nameKr: String,
-    // -rprs_mrkt_kor_name	대표 시장 한글 명	String	Y	40
+    val nameKr: String, // 대표 시장 한글 명
 
     @SerialName("new_hgpr_lwpr_cls_code")
     val newHighLow: String?, // 신 고가 저가 구분 코드 조회하는 종목이 신고/신저에 도달했을 경우에만 조회됨
@@ -33,11 +32,12 @@ data class PriceDetail(
     val tempStop: String, // 임시 정지 여부
 
     @SerialName("stck_prpr")
-    val price: String,
+    val price: String, // 현재가
     @SerialName("prdy_vrss")
     val priceChange: String, // 전일 대비
     @SerialName("prdy_vrss_sign")
-    val priceChangeSign: String, // 전일 대비 부호 1 : 상한 2 : 상승 3 : 보합 4 : 하한 5 : 하락
+    @Serializable(with = PriceChangeSignSerializer::class)
+    val priceChangeSign: PriceChangeSign, // 전일 대비 부호
     @SerialName("prdy_ctrt")
     val priceChangeRate: String, // 전일 대비 등락률
     @SerialName("acml_tr_pbmn")

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.price
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -7,11 +8,11 @@ import kotlinx.serialization.Serializable
 data class PriceResponse(
     val output: PriceDetail?,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
-)
+    override val msgCd: String,
+    override val msg1: String,
+) : ApiResponse
 
 @Serializable
 data class PriceDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/PriceResponse.kt
@@ -1,0 +1,55 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PriceResponse(
+    val output: PriceDetail?,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+)
+
+@Serializable
+data class PriceDetail(
+    @SerialName("iscd_stat_cls_code")
+    val stockState: String, // 00 : 그외 51 : 관리종목 52 : 투자위험 53 : 투자경고 54 : 투자주의 55 : 신용가능
+                            // 57 : 증거금 100% 58 : 거래정지 59 : 단기과열
+    @SerialName("marg_rate")
+    val marginRate: String, // 증거금 비율
+
+    @SerialName("rprs_mrkt_kor_name")
+    val nameKr: String,
+    // -rprs_mrkt_kor_name	대표 시장 한글 명	String	Y	40
+
+    @SerialName("new_hgpr_lwpr_cls_code")
+    val newHighLow: String?, // 신 고가 저가 구분 코드 조회하는 종목이 신고/신저에 도달했을 경우에만 조회됨
+    @SerialName("bstp_kor_isnm")
+    val sectorNameKr: String?, // 업종 한글 종목명
+    @SerialName("temp_stop_yn")
+    val tempStop: String, // 임시 정지 여부
+
+    @SerialName("stck_prpr")
+    val price: String,
+    @SerialName("prdy_vrss")
+    val priceChange: String, // 전일 대비
+    @SerialName("prdy_vrss_sign")
+    val priceChangeSign: String, // 전일 대비 부호 1 : 상한 2 : 상승 3 : 보합 4 : 하한 5 : 하락
+    @SerialName("prdy_ctrt")
+    val priceChangeRate: String, // 전일 대비 등락률
+    @SerialName("acml_tr_pbmn")
+    val volumePrice: String, // 누적 거래대금
+    @SerialName("acml_vol")
+    val volume: String, // 누적 거래량
+    @SerialName("stck_oprc")
+    val open: String, // 시가
+    @SerialName("stck_hgpr")
+    val high: String, // 고가
+    @SerialName("stck_lwpr")
+    val low: String, // 저가
+    @SerialName("stck_sdpr")
+    val previousClosePrice: String, // 기준가(전일종가 or 시가)
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/StockState.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/StockState.kt
@@ -1,0 +1,42 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * 종목 상태 코드
+ */
+enum class StockState(val code: String, val description: String) {
+    NORMAL("00", "정상"),
+    MANAGED("51", "관리종목"),
+    INVESTMENT_RISK("52", "투자위험"),
+    INVESTMENT_WARNING("53", "투자경고"),
+    INVESTMENT_CAUTION("54", "투자주의"),
+    CREDIT_AVAILABLE("55", "신용가능"),
+    MARGIN_100("57", "증거금 100%"),
+    TRADING_HALT("58", "거래정지"),
+    SHORT_TERM_OVERHEATING("59", "단기과열"),
+    UNKNOWN("99", "알 수 없음");
+
+    companion object {
+        fun from(code: String): StockState {
+            return entries.find { it.code == code } ?: UNKNOWN
+        }
+    }
+}
+
+object StockStateSerializer : KSerializer<StockState> {
+    override val descriptor = PrimitiveSerialDescriptor("StockState", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: StockState) {
+        encoder.encodeString(value.code)
+    }
+
+    override fun deserialize(decoder: Decoder): StockState {
+        return StockState.from(decoder.decodeString())
+    }
+}
+

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/TradeResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/TradeResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.price
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,11 +9,11 @@ data class TradeResponse(
     val output1: TradeDetail,
     val output2: TradePriceDetail,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
-)
+    override val msgCd: String,
+    override val msg1: String,
+) : ApiResponse
 
 @Serializable
 data class TradeDetail(

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/price/TradeResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/price/TradeResponse.kt
@@ -1,0 +1,154 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TradeResponse(
+    val output1: TradeDetail,
+    val output2: TradePriceDetail,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+)
+
+@Serializable
+data class TradeDetail(
+
+    @SerialName("aspr_acpt_hour") // 매도호가 접수 시간
+    val offerAcceptHour: String,
+
+    // 매도호가
+    @SerialName("askp1")
+    val sell1: String,
+    @SerialName("askp2")
+    val sell2: String,
+    @SerialName("askp3")
+    val sell3: String,
+    @SerialName("askp4")
+    val sell4: String,
+    @SerialName("askp5")
+    val sell5: String,
+    @SerialName("askp6")
+    val sell6: String,
+    @SerialName("askp7")
+    val sell7: String,
+    @SerialName("askp8")
+    val sell8: String,
+    @SerialName("askp9")
+    val sell9: String,
+    @SerialName("askp10")
+    val sell10: String,
+
+    // 매수호가
+    @SerialName("bidp1")
+    val buy1: String,
+    @SerialName("bidp2")
+    val buy2: String,
+    @SerialName("bidp3")
+    val buy3: String,
+    @SerialName("bidp4")
+    val buy4: String,
+    @SerialName("bidp5")
+    val buy5: String,
+    @SerialName("bidp6")
+    val buy6: String,
+    @SerialName("bidp7")
+    val buy7: String,
+    @SerialName("bidp8")
+    val buy8: String,
+    @SerialName("bidp9")
+    val buy9: String,
+    @SerialName("bidp10")
+    val buy10: String,
+
+    // 매도 잔량
+    @SerialName("askp_rsqn1")
+    val sellQuantity1: String,
+    @SerialName("askp_rsqn2")
+    val sellQuantity2: String,
+    @SerialName("askp_rsqn3")
+    val sellQuantity3: String,
+    @SerialName("askp_rsqn4")
+    val sellQuantity4: String,
+    @SerialName("askp_rsqn5")
+    val sellQuantity5: String,
+    @SerialName("askp_rsqn6")
+    val sellQuantity6: String,
+    @SerialName("askp_rsqn7")
+    val sellQuantity7: String,
+    @SerialName("askp_rsqn8")
+    val sellQuantity8: String,
+    @SerialName("askp_rsqn9")
+    val sellQuantity9: String,
+    @SerialName("askp_rsqn10")
+    val sellQuantity10: String,
+
+    // 매수 잔량
+    @SerialName("bidp_rsqn1")
+    val buyQuantity1: String,
+    @SerialName("bidp_rsqn2")
+    val buyQuantity2: String,
+    @SerialName("bidp_rsqn3")
+    val buyQuantity3: String,
+    @SerialName("bidp_rsqn4")
+    val buyQuantity4: String,
+    @SerialName("bidp_rsqn5")
+    val buyQuantity5: String,
+    @SerialName("bidp_rsqn6")
+    val buyQuantity6: String,
+    @SerialName("bidp_rsqn7")
+    val buyQuantity7: String,
+    @SerialName("bidp_rsqn8")
+    val buyQuantity8: String,
+    @SerialName("bidp_rsqn9")
+    val buyQuantity9: String,
+    @SerialName("bidp_rsqn10")
+    val buyQuantity10: String,
+
+    @SerialName("total_askp_rsqn")
+    val totalSellQuantity: String, // 총 매도호가 잔량
+    @SerialName("total_bidp_rsqn")
+    val totalBuyQuantity: String, // 총 매수호가 잔량
+) {
+    fun sells(): List<Pair<Double, Double>> {
+        val p = listOf(sell1, sell2, sell3, sell4, sell5, sell6, sell7, sell8, sell9, sell10)
+        val q = listOf(sellQuantity1, sellQuantity2, sellQuantity3, sellQuantity4, sellQuantity5, sellQuantity6, sellQuantity7, sellQuantity8, sellQuantity9, sellQuantity10)
+        return p.zip(q).map { it.first.toDouble() to it.second.toDouble() }
+            .reversed() // 매도호가는 역순으로
+    }
+
+    fun buys(): List<Pair<Double, Double>> {
+        val p = listOf(buy1, buy2, buy3, buy4, buy5, buy6, buy7, buy8, buy9, buy10)
+        val q = listOf(buyQuantity1, buyQuantity2, buyQuantity3, buyQuantity4, buyQuantity5, buyQuantity6, buyQuantity7, buyQuantity8, buyQuantity9, buyQuantity10)
+        return p.zip(q).map { it.first.toDouble() to it.second.toDouble() }
+    }
+}
+
+@Serializable
+data class TradePriceDetail(
+    @SerialName("stck_prpr")
+    val price: String, // 주식 현재가
+    @SerialName("stck_oprc")
+    val `open`: String, // 시가
+    @SerialName("stck_hgpr")
+    val high: String, // 고가
+    @SerialName("stck_lwpr")
+    val low: String, // 저가
+
+    @SerialName("stck_sdpr")
+    val prevPrice: String, // 주식 기준가(전일 종가)
+    @SerialName("antc_cnpr")
+    val anticipatedPrice: String, // 예상 체결가 Anticipated Contract Price
+    @SerialName("antc_cntg_vrss")
+    val anticipatedPriceChange: String, // 예상 체결가 대비
+    @SerialName("antc_cntg_prdy_ctrt")
+    val anticipatedPriceChangeRate: String, // 예상 체결가 대비율
+    @SerialName("antc_vol")
+    val anticipatedVolume: String, // 예상 체결수량
+
+    @SerialName("stck_shrn_iscd")
+    val code: String,
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/rank/VolumeRankingResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/rank/VolumeRankingResponse.kt
@@ -1,0 +1,57 @@
+package com.trueedu.spac.api.model.dto.rank
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VolumeRankingResponse(
+    val output: List<VolumeRankingOutput>,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드 - "MCA00000"
+    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
+)
+
+@Serializable
+data class VolumeRankingOutput(
+    @SerialName("hts_kor_isnm")
+    val nameKr: String, // HTS 한글 종목명
+    @SerialName("mksc_shrn_iscd")
+    val code: String, // 유가증권 단축 종목코드
+    @SerialName("data_rank")
+    val rank: String, // 데이터 순위
+    @SerialName("stck_prpr")
+    val price: String, // 주식 현재가
+
+    @SerialName("prdy_vrss_sign")
+    val priceChangeSign: String, // 전일 대비 부호 (0, 1, 2)
+    @SerialName("prdy_vrss")
+    val priceChange: String, // 전일 대비
+    @SerialName("prdy_ctrt")
+    val priceChangeRate: String, // 전일 대비 등락률
+    @SerialName("acml_vol")
+    val volume: String, // 누적 거래량
+    @SerialName("prdy_vol")
+    val prevDayVolume: String, // 전일 거래량
+    @SerialName("lstn_stcn")
+    val totalShares: String, // 상장 주수
+    @SerialName("avrg_vol")
+    val avgVolume: String, // 평균 거래량
+    @SerialName("n_befr_clpr_vrss_prpr_rate")
+    val priceChangeRateFromDays: String, // N일전종가대비현재가대비율
+    @SerialName("vol_inrt")
+    val volumeRate: String, // 거래량증가율
+    @SerialName("vol_tnrt")
+    val turnover: String, // 거래량 회전율
+    @SerialName("nday_vol_tnrt")
+    val turnoverDays: String, // N일 거래량 회전율
+    @SerialName("avrg_tr_pbmn")
+    val avgTurnover: String, // 평균 거래대금
+    @SerialName("tr_pbmn_tnrt")
+    val turnoverRatio: String, // 거래대금 회전율
+    @SerialName("nday_tr_pbmn_tnrt")
+    val turnoverDaysTurnover: String, // N일 거래대금 회전율
+    @SerialName("acml_tr_pbmn")
+    val totalTurnover: String, // 누적 거래대금
+)

--- a/app/src/main/java/com/trueedu/spac/api/model/dto/rank/VolumeRankingResponse.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/rank/VolumeRankingResponse.kt
@@ -1,5 +1,6 @@
 package com.trueedu.spac.api.model.dto.rank
 
+import com.trueedu.spac.api.model.dto.common.ApiResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -7,11 +8,11 @@ import kotlinx.serialization.Serializable
 data class VolumeRankingResponse(
     val output: List<VolumeRankingOutput>,
     @SerialName("rt_cd")
-    val rtCd: String, // 성공 실패 여부 "0" 성공
+    override val rtCd: String,
     @SerialName("msg_cd")
-    val msgCd: String, // 응답코드 - "MCA00000"
-    val msg1: String, // 응답메세지 - "정상처리 되었습니다."
-)
+    override val msgCd: String,
+    override val msg1: String,
+) : ApiResponse
 
 @Serializable
 data class VolumeRankingOutput(

--- a/app/src/main/java/com/trueedu/spac/util/DateTimeExtensions.kt
+++ b/app/src/main/java/com/trueedu/spac/util/DateTimeExtensions.kt
@@ -1,0 +1,35 @@
+package com.trueedu.spac.util
+
+import com.trueedu.spac.api.model.dto.auth.TokenResponse
+import com.trueedu.spac.api.model.dto.order.OrderResponse
+import com.trueedu.spac.api.model.dto.price.DailyPrice
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * DTO 확장 함수들
+ * 문자열로 되어 있는 날짜/시간 필드를 LocalDate/LocalDateTime/LocalTime으로 변환
+ */
+
+/**
+ * TokenResponse 확장 함수
+ */
+fun TokenResponse.getExpiredDateTime(): LocalDateTime? {
+    return accessTokenTokenExpired.toLocalDateTime()
+}
+
+/**
+ * DailyPrice 확장 함수
+ */
+fun DailyPrice.getDate(): LocalDate? {
+    return date?.toLocalDate()
+}
+
+/**
+ * OrderDetail 확장 함수
+ */
+fun com.trueedu.spac.api.model.dto.order.OrderDetail.getOrderTime(): LocalTime? {
+    return orderTime.toLocalTime()
+}
+

--- a/app/src/main/java/com/trueedu/spac/util/DateTimeUtils.kt
+++ b/app/src/main/java/com/trueedu/spac/util/DateTimeUtils.kt
@@ -1,0 +1,145 @@
+package com.trueedu.spac.util
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * 날짜/시간 파싱 유틸리티
+ */
+object DateTimeFormat {
+    /**
+     * yyyy-MM-dd 형식
+     * 예: "2025-10-12"
+     */
+    val DATE_DASH: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+    /**
+     * yyyyMMdd 형식
+     * 예: "20251012"
+     */
+    val DATE_COMPACT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
+    /**
+     * yyyy-MM-dd HH:mm:ss 형식
+     * 예: "2025-10-12 01:30:45"
+     */
+    val DATETIME_DASH: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+    /**
+     * yyyyMMddHHmmss 형식
+     * 예: "20251012013045"
+     */
+    val DATETIME_COMPACT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+
+    /**
+     * HH:mm:ss 형식
+     * 예: "01:30:45"
+     */
+    val TIME_COLON: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+    /**
+     * HHmmss 형식
+     * 예: "013045"
+     */
+    val TIME_COMPACT: DateTimeFormatter = DateTimeFormatter.ofPattern("HHmmss")
+}
+
+/**
+ * String을 LocalDate로 변환
+ * 지원 형식:
+ * - yyyy-MM-dd (예: "2025-10-12")
+ * - yyyyMMdd (예: "20251012")
+ *
+ * @return 변환된 LocalDate 또는 null (파싱 실패 시)
+ */
+fun String.toLocalDate(): LocalDate? {
+    if (this.isBlank()) return null
+
+    return try {
+        when {
+            this.contains("-") -> LocalDate.parse(this, DateTimeFormat.DATE_DASH)
+            this.length == 8 -> LocalDate.parse(this, DateTimeFormat.DATE_COMPACT)
+            else -> null
+        }
+    } catch (e: DateTimeParseException) {
+        null
+    }
+}
+
+/**
+ * String을 LocalDateTime으로 변환
+ * 지원 형식:
+ * - yyyy-MM-dd HH:mm:ss (예: "2025-10-12 01:30:45")
+ * - yyyyMMddHHmmss (예: "20251012013045")
+ *
+ * @return 변환된 LocalDateTime 또는 null (파싱 실패 시)
+ */
+fun String.toLocalDateTime(): LocalDateTime? {
+    if (this.isBlank()) return null
+
+    return try {
+        when {
+            this.contains(" ") -> LocalDateTime.parse(this, DateTimeFormat.DATETIME_DASH)
+            this.length == 14 -> LocalDateTime.parse(this, DateTimeFormat.DATETIME_COMPACT)
+            else -> null
+        }
+    } catch (e: DateTimeParseException) {
+        null
+    }
+}
+
+/**
+ * String을 LocalTime으로 변환
+ * 지원 형식:
+ * - HH:mm:ss (예: "01:30:45")
+ * - HHmmss (예: "013045")
+ *
+ * @return 변환된 LocalTime 또는 null (파싱 실패 시)
+ */
+fun String.toLocalTime(): LocalTime? {
+    if (this.isBlank()) return null
+
+    return try {
+        when {
+            this.contains(":") -> LocalTime.parse(this, DateTimeFormat.TIME_COLON)
+            this.length == 6 -> LocalTime.parse(this, DateTimeFormat.TIME_COMPACT)
+            else -> null
+        }
+    } catch (e: DateTimeParseException) {
+        null
+    }
+}
+
+/**
+ * LocalDate를 yyyy-MM-dd 형식 문자열로 변환
+ */
+fun LocalDate.toDateString(): String = this.format(DateTimeFormat.DATE_DASH)
+
+/**
+ * LocalDate를 yyyyMMdd 형식 문자열로 변환
+ */
+fun LocalDate.toDateCompactString(): String = this.format(DateTimeFormat.DATE_COMPACT)
+
+/**
+ * LocalDateTime을 yyyy-MM-dd HH:mm:ss 형식 문자열로 변환
+ */
+fun LocalDateTime.toDateTimeString(): String = this.format(DateTimeFormat.DATETIME_DASH)
+
+/**
+ * LocalDateTime을 yyyyMMddHHmmss 형식 문자열로 변환
+ */
+fun LocalDateTime.toDateTimeCompactString(): String = this.format(DateTimeFormat.DATETIME_COMPACT)
+
+/**
+ * LocalTime을 HH:mm:ss 형식 문자열로 변환
+ */
+fun LocalTime.toTimeString(): String = this.format(DateTimeFormat.TIME_COLON)
+
+/**
+ * LocalTime을 HHmmss 형식 문자열로 변환
+ */
+fun LocalTime.toTimeCompactString(): String = this.format(DateTimeFormat.TIME_COMPACT)
+

--- a/app/src/test/java/com/trueedu/spac/api/model/dto/common/ApiResponseTest.kt
+++ b/app/src/test/java/com/trueedu/spac/api/model/dto/common/ApiResponseTest.kt
@@ -1,0 +1,233 @@
+package com.trueedu.spac.api.model.dto.common
+
+import com.trueedu.spac.api.model.dto.price.PriceDetail
+import com.trueedu.spac.api.model.dto.price.PriceResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * ApiResponse 인터페이스 유닛 테스트
+ */
+class ApiResponseTest {
+
+    /**
+     * 테스트용 ApiResponse 구현체
+     */
+    @Serializable
+    data class TestApiResponse(
+        @SerialName("rt_cd")
+        override val rtCd: String,
+        @SerialName("msg_cd")
+        override val msgCd: String,
+        override val msg1: String?,
+        val testData: String? = null
+    ) : ApiResponse
+
+    @Test
+    fun `isSuccess - 성공 코드일 때 true 반환`() {
+        // Given
+        val successResponse = TestApiResponse(
+            rtCd = "0",
+            msgCd = "TEST0000",
+            msg1 = "정상처리 되었습니다."
+        )
+
+        // When & Then
+        assertTrue(successResponse.isSuccess())
+    }
+
+    @Test
+    fun `isSuccess - 실패 코드일 때 false 반환`() {
+        // Given
+        val failureResponse = TestApiResponse(
+            rtCd = "1",
+            msgCd = "ERROR0001",
+            msg1 = "오류가 발생했습니다."
+        )
+
+        // When & Then
+        assertFalse(failureResponse.isSuccess())
+    }
+
+    @Test
+    fun `isFailure - 실패 코드일 때 true 반환`() {
+        // Given
+        val failureResponse = TestApiResponse(
+            rtCd = "1",
+            msgCd = "ERROR0001",
+            msg1 = "오류가 발생했습니다."
+        )
+
+        // When & Then
+        assertTrue(failureResponse.isFailure())
+    }
+
+    @Test
+    fun `isFailure - 성공 코드일 때 false 반환`() {
+        // Given
+        val successResponse = TestApiResponse(
+            rtCd = "0",
+            msgCd = "TEST0000",
+            msg1 = "정상처리 되었습니다."
+        )
+
+        // When & Then
+        assertFalse(successResponse.isFailure())
+    }
+
+    @Test
+    fun `RT_CD_SUCCESS 상수값 확인`() {
+        // Then
+        assertEquals("0", ApiResponse.RT_CD_SUCCESS)
+    }
+
+    @Test
+    fun `RT_CD_FAILURE 상수값 확인`() {
+        // Then
+        assertEquals("1", ApiResponse.RT_CD_FAILURE)
+    }
+
+    @Test
+    fun `msg1이 null이어도 isSuccess 동작`() {
+        // Given
+        val response = TestApiResponse(
+            rtCd = "0",
+            msgCd = "TEST0000",
+            msg1 = null
+        )
+
+        // When & Then
+        assertTrue(response.isSuccess())
+        assertEquals("TEST0000", response.msgCd)
+    }
+
+    @Test
+    fun `실제 Response 클래스 - PriceResponse isSuccess 테스트`() {
+        // Given
+        val successResponse = PriceResponse(
+            output = null,
+            rtCd = "0",
+            msgCd = "MCA00000",
+            msg1 = "정상처리 되었습니다."
+        )
+
+        val failureResponse = PriceResponse(
+            output = null,
+            rtCd = "1",
+            msgCd = "ERROR0001",
+            msg1 = "오류가 발생했습니다."
+        )
+
+        // When & Then
+        assertTrue(successResponse.isSuccess())
+        assertFalse(successResponse.isFailure())
+
+        assertFalse(failureResponse.isSuccess())
+        assertTrue(failureResponse.isFailure())
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 응답 처리`() {
+        // Given
+        val response = TestApiResponse(
+            rtCd = "0",
+            msgCd = "TEST0000",
+            msg1 = "성공",
+            testData = "result"
+        )
+
+        // When
+        val result = if (response.isSuccess()) {
+            "처리 성공: ${response.testData}"
+        } else {
+            "처리 실패: ${response.msg1}"
+        }
+
+        // Then
+        assertEquals("처리 성공: result", result)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 공통 처리 함수`() {
+        // Given
+        var successCalled = false
+        var failureCalled = false
+
+        val successResponse = TestApiResponse("0", "TEST0000", "성공")
+        val failureResponse = TestApiResponse("1", "ERROR0001", "실패")
+
+        fun <T : ApiResponse> handleResponse(response: T, onSuccess: () -> Unit, onFailure: () -> Unit) {
+            if (response.isSuccess()) onSuccess() else onFailure()
+        }
+
+        // When
+        handleResponse(successResponse, { successCalled = true }, { failureCalled = true })
+        val failedBefore = failureCalled
+        handleResponse(failureResponse, { successCalled = false }, { failureCalled = true })
+
+        // Then
+        assertTrue(successCalled)
+        assertFalse(failedBefore) // 첫 번째 호출에서는 실패 콜백이 호출되지 않음
+        assertTrue(failureCalled) // 두 번째 호출에서는 실패 콜백이 호출됨
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - when 표현식으로 여러 응답 타입 처리`() {
+        // Given
+        val response: ApiResponse = TestApiResponse("0", "TEST0000", "성공")
+
+        // When
+        val message = when {
+            response.isFailure() -> "오류: ${response.msg1}"
+            response is PriceResponse -> "가격 데이터"
+            response is TestApiResponse -> "테스트 데이터"
+            else -> "알 수 없음"
+        }
+
+        // Then
+        assertEquals("테스트 데이터", message)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 응답 리스트 필터링`() {
+        // Given
+        val responses = listOf(
+            TestApiResponse("0", "TEST0000", "성공1"),
+            TestApiResponse("1", "ERROR0001", "실패1"),
+            TestApiResponse("0", "TEST0000", "성공2"),
+            TestApiResponse("1", "ERROR0002", "실패2"),
+            TestApiResponse("0", "TEST0000", "성공3")
+        )
+
+        // When
+        val successResponses = responses.filter { it.isSuccess() }
+        val failureResponses = responses.filter { it.isFailure() }
+
+        // Then
+        assertEquals(3, successResponses.size)
+        assertEquals(2, failureResponses.size)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 에러 메시지 수집`() {
+        // Given
+        val responses = listOf(
+            TestApiResponse("0", "TEST0000", "성공"),
+            TestApiResponse("1", "ERROR0001", "오류1"),
+            TestApiResponse("1", "ERROR0002", "오류2")
+        )
+
+        // When
+        val errorMessages = responses
+            .filter { it.isFailure() }
+            .mapNotNull { it.msg1 }
+
+        // Then
+        assertEquals(2, errorMessages.size)
+        assertTrue(errorMessages.contains("오류1"))
+        assertTrue(errorMessages.contains("오류2"))
+    }
+}
+

--- a/app/src/test/java/com/trueedu/spac/api/model/dto/price/PriceChangeSignTest.kt
+++ b/app/src/test/java/com/trueedu/spac/api/model/dto/price/PriceChangeSignTest.kt
@@ -1,0 +1,208 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * PriceChangeSign Enum 유닛 테스트
+ */
+class PriceChangeSignTest {
+
+    @Test
+    fun `from - 올바른 코드를 PriceChangeSign으로 변환`() {
+        // When & Then
+        assertEquals(PriceChangeSign.UPPER_LIMIT, PriceChangeSign.from("1"))
+        assertEquals(PriceChangeSign.RISE, PriceChangeSign.from("2"))
+        assertEquals(PriceChangeSign.UNCHANGED, PriceChangeSign.from("3"))
+        assertEquals(PriceChangeSign.LOWER_LIMIT, PriceChangeSign.from("4"))
+        assertEquals(PriceChangeSign.FALL, PriceChangeSign.from("5"))
+    }
+
+    @Test
+    fun `from - 알 수 없는 코드는 UNKNOWN 반환`() {
+        // When
+        val result1 = PriceChangeSign.from("0")
+        val result2 = PriceChangeSign.from("9")
+        val result3 = PriceChangeSign.from("")
+        val result4 = PriceChangeSign.from("invalid")
+
+        // Then
+        assertEquals(PriceChangeSign.UNKNOWN, result1)
+        assertEquals(PriceChangeSign.UNKNOWN, result2)
+        assertEquals(PriceChangeSign.UNKNOWN, result3)
+        assertEquals(PriceChangeSign.UNKNOWN, result4)
+    }
+
+    @Test
+    fun `code 프로퍼티가 올바른 값을 반환`() {
+        // Then
+        assertEquals("1", PriceChangeSign.UPPER_LIMIT.code)
+        assertEquals("2", PriceChangeSign.RISE.code)
+        assertEquals("3", PriceChangeSign.UNCHANGED.code)
+        assertEquals("4", PriceChangeSign.LOWER_LIMIT.code)
+        assertEquals("5", PriceChangeSign.FALL.code)
+    }
+
+    @Test
+    fun `description 프로퍼티가 올바른 값을 반환`() {
+        // Then
+        assertEquals("상한", PriceChangeSign.UPPER_LIMIT.description)
+        assertEquals("상승", PriceChangeSign.RISE.description)
+        assertEquals("보합", PriceChangeSign.UNCHANGED.description)
+        assertEquals("하한", PriceChangeSign.LOWER_LIMIT.description)
+        assertEquals("하락", PriceChangeSign.FALL.description)
+    }
+
+    @Test
+    fun `isPositive - 상한과 상승은 true 반환`() {
+        // Then
+        assertTrue(PriceChangeSign.UPPER_LIMIT.isPositive())
+        assertTrue(PriceChangeSign.RISE.isPositive())
+        assertFalse(PriceChangeSign.UNCHANGED.isPositive())
+        assertFalse(PriceChangeSign.LOWER_LIMIT.isPositive())
+        assertFalse(PriceChangeSign.FALL.isPositive())
+    }
+
+    @Test
+    fun `isNegative - 하한과 하락은 true 반환`() {
+        // Then
+        assertFalse(PriceChangeSign.UPPER_LIMIT.isNegative())
+        assertFalse(PriceChangeSign.RISE.isNegative())
+        assertFalse(PriceChangeSign.UNCHANGED.isNegative())
+        assertTrue(PriceChangeSign.LOWER_LIMIT.isNegative())
+        assertTrue(PriceChangeSign.FALL.isNegative())
+    }
+
+    @Test
+    fun `isUnchanged - 보합만 true 반환`() {
+        // Then
+        assertFalse(PriceChangeSign.UPPER_LIMIT.isUnchanged())
+        assertFalse(PriceChangeSign.RISE.isUnchanged())
+        assertTrue(PriceChangeSign.UNCHANGED.isUnchanged())
+        assertFalse(PriceChangeSign.LOWER_LIMIT.isUnchanged())
+        assertFalse(PriceChangeSign.FALL.isUnchanged())
+    }
+
+    @Test
+    fun `PriceChangeSignSerializer - serialization 테스트`() {
+        // Given
+        val json = Json
+        val sign = PriceChangeSign.RISE
+
+        // When
+        val serialized = json.encodeToString(PriceChangeSignSerializer, sign)
+
+        // Then
+        assertEquals("\"2\"", serialized)
+    }
+
+    @Test
+    fun `PriceChangeSignSerializer - deserialization 테스트`() {
+        // Given
+        val json = Json
+        val jsonString = "\"4\""
+
+        // When
+        val deserialized = json.decodeFromString(PriceChangeSignSerializer, jsonString)
+
+        // Then
+        assertEquals(PriceChangeSign.LOWER_LIMIT, deserialized)
+    }
+
+    @Test
+    fun `PriceChangeSignSerializer - 알 수 없는 코드 deserialization`() {
+        // Given
+        val json = Json
+        val jsonString = "\"9\""
+
+        // When
+        val deserialized = json.decodeFromString(PriceChangeSignSerializer, jsonString)
+
+        // Then
+        assertEquals(PriceChangeSign.UNKNOWN, deserialized)
+    }
+
+    @Test
+    fun `PriceChangeSignSerializer - 양방향 변환 테스트`() {
+        // Given
+        val json = Json
+        val originalSign = PriceChangeSign.UPPER_LIMIT
+
+        // When
+        val serialized = json.encodeToString(PriceChangeSignSerializer, originalSign)
+        val deserialized = json.decodeFromString(PriceChangeSignSerializer, serialized)
+
+        // Then
+        assertEquals(originalSign, deserialized)
+    }
+
+    @Test
+    fun `모든 PriceChangeSign entries 순회 테스트`() {
+        // When
+        val allSigns = PriceChangeSign.entries
+
+        // Then
+        assertEquals(6, allSigns.size)
+        assertTrue(allSigns.contains(PriceChangeSign.UPPER_LIMIT))
+        assertTrue(allSigns.contains(PriceChangeSign.UNKNOWN))
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 가격 변동 색상 결정`() {
+        // Given
+        val riseSign = PriceChangeSign.RISE
+        val fallSign = PriceChangeSign.FALL
+        val unchangedSign = PriceChangeSign.UNCHANGED
+
+        // When
+        val riseColor = if (riseSign.isPositive()) "red" else if (riseSign.isNegative()) "blue" else "gray"
+        val fallColor = if (fallSign.isPositive()) "red" else if (fallSign.isNegative()) "blue" else "gray"
+        val unchangedColor = if (unchangedSign.isUnchanged()) "gray" else "unknown"
+
+        // Then
+        assertEquals("red", riseColor)
+        assertEquals("blue", fallColor)
+        assertEquals("gray", unchangedColor)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - when 표현식에서 사용`() {
+        // Given
+        val sign = PriceChangeSign.UPPER_LIMIT
+
+        // When
+        val message = when (sign) {
+            PriceChangeSign.UPPER_LIMIT -> "상한가"
+            PriceChangeSign.LOWER_LIMIT -> "하한가"
+            PriceChangeSign.RISE -> "상승"
+            PriceChangeSign.FALL -> "하락"
+            PriceChangeSign.UNCHANGED -> "보합"
+            PriceChangeSign.UNKNOWN -> "알 수 없음"
+        }
+
+        // Then
+        assertEquals("상한가", message)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 상승 종목 필터링`() {
+        // Given
+        val signs = listOf(
+            PriceChangeSign.UPPER_LIMIT,
+            PriceChangeSign.RISE,
+            PriceChangeSign.UNCHANGED,
+            PriceChangeSign.FALL,
+            PriceChangeSign.LOWER_LIMIT
+        )
+
+        // When
+        val positiveSigns = signs.filter { it.isPositive() }
+
+        // Then
+        assertEquals(2, positiveSigns.size)
+        assertTrue(positiveSigns.contains(PriceChangeSign.UPPER_LIMIT))
+        assertTrue(positiveSigns.contains(PriceChangeSign.RISE))
+    }
+}
+

--- a/app/src/test/java/com/trueedu/spac/api/model/dto/price/StockStateTest.kt
+++ b/app/src/test/java/com/trueedu/spac/api/model/dto/price/StockStateTest.kt
@@ -1,0 +1,150 @@
+package com.trueedu.spac.api.model.dto.price
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * StockState Enum 유닛 테스트
+ */
+class StockStateTest {
+
+    @Test
+    fun `from - 정상 코드를 StockState로 변환`() {
+        // When & Then
+        assertEquals(StockState.NORMAL, StockState.from("00"))
+        assertEquals(StockState.MANAGED, StockState.from("51"))
+        assertEquals(StockState.INVESTMENT_RISK, StockState.from("52"))
+        assertEquals(StockState.INVESTMENT_WARNING, StockState.from("53"))
+        assertEquals(StockState.INVESTMENT_CAUTION, StockState.from("54"))
+        assertEquals(StockState.CREDIT_AVAILABLE, StockState.from("55"))
+        assertEquals(StockState.MARGIN_100, StockState.from("57"))
+        assertEquals(StockState.TRADING_HALT, StockState.from("58"))
+        assertEquals(StockState.SHORT_TERM_OVERHEATING, StockState.from("59"))
+    }
+
+    @Test
+    fun `from - 알 수 없는 코드는 UNKNOWN 반환`() {
+        // When
+        val result1 = StockState.from("99")
+        val result2 = StockState.from("unknown")
+        val result3 = StockState.from("")
+
+        // Then
+        assertEquals(StockState.UNKNOWN, result1)
+        assertEquals(StockState.UNKNOWN, result2)
+        assertEquals(StockState.UNKNOWN, result3)
+    }
+
+    @Test
+    fun `code 프로퍼티가 올바른 값을 반환`() {
+        // Then
+        assertEquals("00", StockState.NORMAL.code)
+        assertEquals("51", StockState.MANAGED.code)
+        assertEquals("58", StockState.TRADING_HALT.code)
+    }
+
+    @Test
+    fun `description 프로퍼티가 올바른 값을 반환`() {
+        // Then
+        assertEquals("정상", StockState.NORMAL.description)
+        assertEquals("관리종목", StockState.MANAGED.description)
+        assertEquals("거래정지", StockState.TRADING_HALT.description)
+    }
+
+    @Test
+    fun `StockStateSerializer - serialization 테스트`() {
+        // Given
+        val json = Json
+        val stockState = StockState.TRADING_HALT
+
+        // When
+        val serialized = json.encodeToString(StockStateSerializer, stockState)
+
+        // Then
+        assertEquals("\"58\"", serialized)
+    }
+
+    @Test
+    fun `StockStateSerializer - deserialization 테스트`() {
+        // Given
+        val json = Json
+        val jsonString = "\"51\""
+
+        // When
+        val deserialized = json.decodeFromString(StockStateSerializer, jsonString)
+
+        // Then
+        assertEquals(StockState.MANAGED, deserialized)
+    }
+
+    @Test
+    fun `StockStateSerializer - 알 수 없는 코드 deserialization`() {
+        // Given
+        val json = Json
+        val jsonString = "\"99\""
+
+        // When
+        val deserialized = json.decodeFromString(StockStateSerializer, jsonString)
+
+        // Then
+        assertEquals(StockState.UNKNOWN, deserialized)
+    }
+
+    @Test
+    fun `StockStateSerializer - 양방향 변환 테스트`() {
+        // Given
+        val json = Json
+        val originalState = StockState.INVESTMENT_WARNING
+
+        // When
+        val serialized = json.encodeToString(StockStateSerializer, originalState)
+        val deserialized = json.decodeFromString(StockStateSerializer, serialized)
+
+        // Then
+        assertEquals(originalState, deserialized)
+    }
+
+    @Test
+    fun `모든 StockState entries 순회 테스트`() {
+        // When
+        val allStates = StockState.entries
+
+        // Then
+        assertEquals(10, allStates.size)
+        assertTrue(allStates.contains(StockState.NORMAL))
+        assertTrue(allStates.contains(StockState.UNKNOWN))
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - 거래 가능 여부 판단`() {
+        // Given
+        val normalStock = StockState.NORMAL
+        val haltedStock = StockState.TRADING_HALT
+        val managedStock = StockState.MANAGED
+
+        // Then
+        assertTrue(normalStock == StockState.NORMAL)
+        assertTrue(haltedStock == StockState.TRADING_HALT)
+        assertTrue(managedStock == StockState.MANAGED)
+    }
+
+    @Test
+    fun `실제 사용 시나리오 - when 표현식에서 사용`() {
+        // Given
+        val state = StockState.TRADING_HALT
+
+        // When
+        val message = when (state) {
+            StockState.TRADING_HALT -> "거래 불가능"
+            StockState.MANAGED -> "주의 필요"
+            StockState.NORMAL -> "정상 거래 가능"
+            else -> "확인 필요"
+        }
+
+        // Then
+        assertEquals("거래 불가능", message)
+    }
+}
+

--- a/app/src/test/java/com/trueedu/spac/util/DateTimeExtensionsTest.kt
+++ b/app/src/test/java/com/trueedu/spac/util/DateTimeExtensionsTest.kt
@@ -1,0 +1,209 @@
+package com.trueedu.spac.util
+
+import com.trueedu.spac.api.model.dto.auth.TokenResponse
+import com.trueedu.spac.api.model.dto.order.OrderDetail
+import com.trueedu.spac.api.model.dto.price.DailyPrice
+import org.junit.Assert.*
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * DateTimeExtensions 유닛 테스트
+ */
+class DateTimeExtensionsTest {
+
+    @Test
+    fun `TokenResponse - getExpiredDateTime 변환 성공`() {
+        // Given
+        val tokenResponse = TokenResponse(
+            accessToken = "test_token",
+            tokenType = "Bearer",
+            expiresIn = 7776000,
+            accessTokenTokenExpired = "2025-10-12 01:30:45"
+        )
+
+        // When
+        val expiredDateTime = tokenResponse.getExpiredDateTime()
+
+        // Then
+        assertNotNull(expiredDateTime)
+        assertEquals(2025, expiredDateTime?.year)
+        assertEquals(10, expiredDateTime?.monthValue)
+        assertEquals(12, expiredDateTime?.dayOfMonth)
+        assertEquals(1, expiredDateTime?.hour)
+        assertEquals(30, expiredDateTime?.minute)
+        assertEquals(45, expiredDateTime?.second)
+    }
+
+    @Test
+    fun `TokenResponse - 잘못된 형식은 null 반환`() {
+        // Given
+        val tokenResponse = TokenResponse(
+            accessToken = "test_token",
+            tokenType = "Bearer",
+            expiresIn = 7776000,
+            accessTokenTokenExpired = "invalid_date"
+        )
+
+        // When
+        val expiredDateTime = tokenResponse.getExpiredDateTime()
+
+        // Then
+        assertNull(expiredDateTime)
+    }
+
+    @Test
+    fun `DailyPrice - getDate 변환 성공`() {
+        // Given
+        val dailyPrice = DailyPrice(
+            date = "20251012",
+            close = "50000",
+            open = "49000",
+            high = "51000",
+            low = "48500",
+            volume = "1000000",
+            volumeAmount = "50000000000",
+            changeSign = "2",
+            change = "1000"
+        )
+
+        // When
+        val date = dailyPrice.getDate()
+
+        // Then
+        assertNotNull(date)
+        assertEquals(2025, date?.year)
+        assertEquals(10, date?.monthValue)
+        assertEquals(12, date?.dayOfMonth)
+    }
+
+    @Test
+    fun `DailyPrice - null 날짜는 null 반환`() {
+        // Given
+        val dailyPrice = DailyPrice(
+            date = null,
+            close = "50000",
+            open = "49000",
+            high = "51000",
+            low = "48500",
+            volume = "1000000",
+            volumeAmount = "50000000000",
+            changeSign = "2",
+            change = "1000"
+        )
+
+        // When
+        val date = dailyPrice.getDate()
+
+        // Then
+        assertNull(date)
+    }
+
+    @Test
+    fun `OrderDetail - getOrderTime 변환 성공`() {
+        // Given
+        val orderDetail = OrderDetail(
+            krxForwardingOrderOrgNumber = "12345",
+            orderNumber = "67890",
+            orderTime = "013045"
+        )
+
+        // When
+        val orderTime = orderDetail.getOrderTime()
+
+        // Then
+        assertNotNull(orderTime)
+        assertEquals(1, orderTime?.hour)
+        assertEquals(30, orderTime?.minute)
+        assertEquals(45, orderTime?.second)
+    }
+
+    @Test
+    fun `OrderDetail - 잘못된 시간 형식은 null 반환`() {
+        // Given
+        val orderDetail = OrderDetail(
+            krxForwardingOrderOrgNumber = "12345",
+            orderNumber = "67890",
+            orderTime = "invalid"
+        )
+
+        // When
+        val orderTime = orderDetail.getOrderTime()
+
+        // Then
+        assertNull(orderTime)
+    }
+
+    // ========================================
+    // 실제 사용 시나리오 테스트
+    // ========================================
+
+    @Test
+    fun `시나리오 - 일별 가격 데이터를 날짜로 필터링`() {
+        // Given
+        val prices = listOf(
+            DailyPrice("20251010", "50000", "49000", "51000", "48500", "1000000", "50000000000", "2", "1000"),
+            DailyPrice("20251011", "51000", "50000", "52000", "49500", "1100000", "55000000000", "2", "1000"),
+            DailyPrice("20251012", "52000", "51000", "53000", "50500", "1200000", "60000000000", "2", "1000"),
+            DailyPrice("20251013", "53000", "52000", "54000", "51500", "1300000", "65000000000", "2", "1000")
+        )
+
+        val targetDate = LocalDate.of(2025, 10, 12)
+
+        // When
+        val filteredPrices = prices.filter { it.getDate() == targetDate }
+
+        // Then
+        assertEquals(1, filteredPrices.size)
+        assertEquals("52000", filteredPrices.first().close)
+    }
+
+    @Test
+    fun `시나리오 - 최근 7일 데이터 필터링`() {
+        // Given
+        val today = LocalDate.of(2025, 10, 12)
+        val sevenDaysAgo = today.minusDays(7) // 2025-10-05
+
+        val prices = listOf(
+            DailyPrice("20251001", "50000", "49000", "51000", "48500", "1000000", "50000000000", "2", "1000"), // 10-01 (제외)
+            DailyPrice("20251008", "51000", "50000", "52000", "49500", "1100000", "55000000000", "2", "1000"), // 10-08 (포함)
+            DailyPrice("20251010", "52000", "51000", "53000", "50500", "1200000", "60000000000", "2", "1000"), // 10-10 (포함)
+            DailyPrice("20251012", "53000", "52000", "54000", "51500", "1300000", "65000000000", "2", "1000")  // 10-12 (포함)
+        )
+
+        // When
+        val recentPrices = prices.filter { price ->
+            price.getDate()?.let { date ->
+                (date.isAfter(sevenDaysAgo) || date.isEqual(sevenDaysAgo)) && !date.isAfter(today)
+            } ?: false
+        }
+
+        // Then
+        assertEquals(3, recentPrices.size)
+    }
+
+    @Test
+    fun `시나리오 - 주문 시간이 오전 9시 이후인 주문만 필터링`() {
+        // Given
+        val orders = listOf(
+            OrderDetail("12345", "1", "083000"),  // 08:30:00
+            OrderDetail("12345", "2", "093000"),  // 09:30:00
+            OrderDetail("12345", "3", "103000"),  // 10:30:00
+            OrderDetail("12345", "4", "083500")   // 08:35:00
+        )
+
+        val nineAM = LocalTime.of(9, 0, 0)
+
+        // When
+        val afternoonOrders = orders.filter { order ->
+            order.getOrderTime()?.isAfter(nineAM) ?: false
+        }
+
+        // Then
+        assertEquals(2, afternoonOrders.size)
+        assertTrue(afternoonOrders.any { it.orderNumber == "2" })
+        assertTrue(afternoonOrders.any { it.orderNumber == "3" })
+    }
+}
+

--- a/app/src/test/java/com/trueedu/spac/util/DateTimeUtilsTest.kt
+++ b/app/src/test/java/com/trueedu/spac/util/DateTimeUtilsTest.kt
@@ -1,0 +1,446 @@
+package com.trueedu.spac.util
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * DateTimeUtils 유닛 테스트
+ */
+class DateTimeUtilsTest {
+
+    // ========================================
+    // toLocalDate() 테스트
+    // ========================================
+
+    @Test
+    fun `toLocalDate - yyyy-MM-dd 형식 파싱 성공`() {
+        // Given
+        val dateString = "2025-10-12"
+
+        // When
+        val result = dateString.toLocalDate()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2025, result?.year)
+        assertEquals(10, result?.monthValue)
+        assertEquals(12, result?.dayOfMonth)
+    }
+
+    @Test
+    fun `toLocalDate - yyyyMMdd 형식 파싱 성공`() {
+        // Given
+        val dateString = "20251012"
+
+        // When
+        val result = dateString.toLocalDate()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2025, result?.year)
+        assertEquals(10, result?.monthValue)
+        assertEquals(12, result?.dayOfMonth)
+    }
+
+    @Test
+    fun `toLocalDate - 빈 문자열은 null 반환`() {
+        // Given
+        val emptyString = ""
+
+        // When
+        val result = emptyString.toLocalDate()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalDate - 공백 문자열은 null 반환`() {
+        // Given
+        val blankString = "   "
+
+        // When
+        val result = blankString.toLocalDate()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalDate - 잘못된 형식은 null 반환`() {
+        // Given
+        val invalidString = "2025/10/12"
+
+        // When
+        val result = invalidString.toLocalDate()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalDate - 잘못된 날짜는 null 반환`() {
+        // Given
+        val invalidDate = "2025-13-32"
+
+        // When
+        val result = invalidDate.toLocalDate()
+
+        // Then
+        assertNull(result)
+    }
+
+    // ========================================
+    // toLocalDateTime() 테스트
+    // ========================================
+
+    @Test
+    fun `toLocalDateTime - yyyy-MM-dd HH_mm_ss 형식 파싱 성공`() {
+        // Given
+        val dateTimeString = "2025-10-12 01:30:45"
+
+        // When
+        val result = dateTimeString.toLocalDateTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2025, result?.year)
+        assertEquals(10, result?.monthValue)
+        assertEquals(12, result?.dayOfMonth)
+        assertEquals(1, result?.hour)
+        assertEquals(30, result?.minute)
+        assertEquals(45, result?.second)
+    }
+
+    @Test
+    fun `toLocalDateTime - yyyyMMddHHmmss 형식 파싱 성공`() {
+        // Given
+        val dateTimeString = "20251012013045"
+
+        // When
+        val result = dateTimeString.toLocalDateTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2025, result?.year)
+        assertEquals(10, result?.monthValue)
+        assertEquals(12, result?.dayOfMonth)
+        assertEquals(1, result?.hour)
+        assertEquals(30, result?.minute)
+        assertEquals(45, result?.second)
+    }
+
+    @Test
+    fun `toLocalDateTime - 빈 문자열은 null 반환`() {
+        // Given
+        val emptyString = ""
+
+        // When
+        val result = emptyString.toLocalDateTime()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalDateTime - 잘못된 형식은 null 반환`() {
+        // Given
+        val invalidString = "2025/10/12 01:30:45"
+
+        // When
+        val result = invalidString.toLocalDateTime()
+
+        // Then
+        assertNull(result)
+    }
+
+    // ========================================
+    // toLocalTime() 테스트
+    // ========================================
+
+    @Test
+    fun `toLocalTime - HH_mm_ss 형식 파싱 성공`() {
+        // Given
+        val timeString = "01:30:45"
+
+        // When
+        val result = timeString.toLocalTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(1, result?.hour)
+        assertEquals(30, result?.minute)
+        assertEquals(45, result?.second)
+    }
+
+    @Test
+    fun `toLocalTime - HHmmss 형식 파싱 성공`() {
+        // Given
+        val timeString = "013045"
+
+        // When
+        val result = timeString.toLocalTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(1, result?.hour)
+        assertEquals(30, result?.minute)
+        assertEquals(45, result?.second)
+    }
+
+    @Test
+    fun `toLocalTime - 빈 문자열은 null 반환`() {
+        // Given
+        val emptyString = ""
+
+        // When
+        val result = emptyString.toLocalTime()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalTime - 잘못된 형식은 null 반환`() {
+        // Given
+        val invalidString = "1:30:45"
+
+        // When
+        val result = invalidString.toLocalTime()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `toLocalTime - 잘못된 시간은 null 반환`() {
+        // Given
+        val invalidTime = "25:70:80"
+
+        // When
+        val result = invalidTime.toLocalTime()
+
+        // Then
+        assertNull(result)
+    }
+
+    // ========================================
+    // LocalDate to String 변환 테스트
+    // ========================================
+
+    @Test
+    fun `toDateString - LocalDate를 yyyy-MM-dd 형식으로 변환`() {
+        // Given
+        val date = LocalDate.of(2025, 10, 12)
+
+        // When
+        val result = date.toDateString()
+
+        // Then
+        assertEquals("2025-10-12", result)
+    }
+
+    @Test
+    fun `toDateCompactString - LocalDate를 yyyyMMdd 형식으로 변환`() {
+        // Given
+        val date = LocalDate.of(2025, 10, 12)
+
+        // When
+        val result = date.toDateCompactString()
+
+        // Then
+        assertEquals("20251012", result)
+    }
+
+    // ========================================
+    // LocalDateTime to String 변환 테스트
+    // ========================================
+
+    @Test
+    fun `toDateTimeString - LocalDateTime을 yyyy-MM-dd HH_mm_ss 형식으로 변환`() {
+        // Given
+        val dateTime = LocalDateTime.of(2025, 10, 12, 1, 30, 45)
+
+        // When
+        val result = dateTime.toDateTimeString()
+
+        // Then
+        assertEquals("2025-10-12 01:30:45", result)
+    }
+
+    @Test
+    fun `toDateTimeCompactString - LocalDateTime을 yyyyMMddHHmmss 형식으로 변환`() {
+        // Given
+        val dateTime = LocalDateTime.of(2025, 10, 12, 1, 30, 45)
+
+        // When
+        val result = dateTime.toDateTimeCompactString()
+
+        // Then
+        assertEquals("20251012013045", result)
+    }
+
+    // ========================================
+    // LocalTime to String 변환 테스트
+    // ========================================
+
+    @Test
+    fun `toTimeString - LocalTime을 HH_mm_ss 형식으로 변환`() {
+        // Given
+        val time = LocalTime.of(1, 30, 45)
+
+        // When
+        val result = time.toTimeString()
+
+        // Then
+        assertEquals("01:30:45", result)
+    }
+
+    @Test
+    fun `toTimeCompactString - LocalTime을 HHmmss 형식으로 변환`() {
+        // Given
+        val time = LocalTime.of(1, 30, 45)
+
+        // When
+        val result = time.toTimeCompactString()
+
+        // Then
+        assertEquals("013045", result)
+    }
+
+    // ========================================
+    // 양방향 변환 테스트
+    // ========================================
+
+    @Test
+    fun `날짜 양방향 변환 - dash 형식`() {
+        // Given
+        val originalString = "2025-10-12"
+
+        // When
+        val date = originalString.toLocalDate()
+        val backToString = date?.toDateString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    @Test
+    fun `날짜 양방향 변환 - compact 형식`() {
+        // Given
+        val originalString = "20251012"
+
+        // When
+        val date = originalString.toLocalDate()
+        val backToString = date?.toDateCompactString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    @Test
+    fun `날짜시간 양방향 변환 - dash 형식`() {
+        // Given
+        val originalString = "2025-10-12 01:30:45"
+
+        // When
+        val dateTime = originalString.toLocalDateTime()
+        val backToString = dateTime?.toDateTimeString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    @Test
+    fun `날짜시간 양방향 변환 - compact 형식`() {
+        // Given
+        val originalString = "20251012013045"
+
+        // When
+        val dateTime = originalString.toLocalDateTime()
+        val backToString = dateTime?.toDateTimeCompactString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    @Test
+    fun `시간 양방향 변환 - colon 형식`() {
+        // Given
+        val originalString = "01:30:45"
+
+        // When
+        val time = originalString.toLocalTime()
+        val backToString = time?.toTimeString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    @Test
+    fun `시간 양방향 변환 - compact 형식`() {
+        // Given
+        val originalString = "013045"
+
+        // When
+        val time = originalString.toLocalTime()
+        val backToString = time?.toTimeCompactString()
+
+        // Then
+        assertEquals(originalString, backToString)
+    }
+
+    // ========================================
+    // Edge Case 테스트
+    // ========================================
+
+    @Test
+    fun `윤년 날짜 파싱`() {
+        // Given
+        val leapYearDate = "2024-02-29"
+
+        // When
+        val result = leapYearDate.toLocalDate()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2024, result?.year)
+        assertEquals(2, result?.monthValue)
+        assertEquals(29, result?.dayOfMonth)
+    }
+
+
+    @Test
+    fun `자정 시간 파싱`() {
+        // Given
+        val midnight = "00:00:00"
+
+        // When
+        val result = midnight.toLocalTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(0, result?.hour)
+        assertEquals(0, result?.minute)
+        assertEquals(0, result?.second)
+    }
+
+    @Test
+    fun `23시 59분 59초 파싱`() {
+        // Given
+        val lastSecond = "23:59:59"
+
+        // When
+        val result = lastSecond.toLocalTime()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(23, result?.hour)
+        assertEquals(59, result?.minute)
+        assertEquals(59, result?.second)
+    }
+}
+


### PR DESCRIPTION
true-project 에서 복사

[ ] 숫자형 필드를 String에서 Int/Long/Double로 변경 고려
[ ] 상태 코드를 Enum으로 변환
[ ] 공통 응답 인터페이스 추가
[ ] Magic String/Number를 상수로 추출
[ ] StockInfo 추상 클래스를 프로퍼티 기반으로 리팩토링
[ ] 날짜/시간 파싱 유틸리티 추가
[ ] 단위 테스트 추가
[ ] 잘못된 주석 수정