### PR TITLE
GH-126 Admob Native Ad에서 MediaView 사용하도록 변경

### DIFF
--- a/app/src/main/java/com/trueedu/spac/ui/ads/TrueNativeAdView.kt
+++ b/app/src/main/java/com/trueedu/spac/ui/ads/TrueNativeAdView.kt
@@ -2,15 +2,13 @@ package com.trueedu.spac.ui.ads
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintLayout
-import coil.load
-import coil.transform.CircleCropTransformation
+import com.google.android.gms.ads.nativead.MediaView
 import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.nativead.NativeAdView
 import com.trueedu.spac.R
@@ -22,7 +20,7 @@ class TrueNativeAdView(context: Context) : ConstraintLayout(context) {
 
     fun setNativeAd(nativeAd: NativeAd, colorScheme: ColorScheme) {
         val nativeAdView = findViewById<NativeAdView>(R.id.nativeAdView)
-        val icon = findViewById<ImageView>(R.id.icon)
+        val mediaView = findViewById<MediaView>(R.id.icon)
         val title = findViewById<TextView>(R.id.title).also {
             it.setTextColor(colorScheme.primary.toArgb())
         }
@@ -39,10 +37,10 @@ class TrueNativeAdView(context: Context) : ConstraintLayout(context) {
             it.setTextColor(colorScheme.secondary.toArgb())
         }
 
-        nativeAdView.iconView = icon
-        val url = nativeAd.icon?.uri ?: nativeAd.images.firstOrNull()?.uri ?: "" //icon이 없는 경우가 있다
-        icon.load(url.toString()) {
-            transformations(CircleCropTransformation())
+        // MediaView를 사용하여 이미지/비디오 자산 표시
+        nativeAdView.mediaView = mediaView
+        nativeAd.mediaContent?.let { mediaContent ->
+            mediaView.setMediaContent(mediaContent)
         }
 
         nativeAdView.headlineView = title.apply {

--- a/app/src/main/res/layout/admob_native_banner_layout.xml
+++ b/app/src/main/res/layout/admob_native_banner_layout.xml
@@ -16,13 +16,12 @@
             android:layout_gravity="center"
             android:orientation="vertical">
 
-            <ImageView
+            <com.google.android.gms.ads.nativead.MediaView
                 android:id="@+id/icon"
                 android:layout_width="36dp"
                 android:layout_height="36dp"
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
-                android:adjustViewBounds="true"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/layout_text"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
- ImageView를 MediaView로 교체하여 메인 이미지/비디오 자산 표시
- Admob validator 경고 해결 (MediaView not used for main image or video asset)
- mediaContent를 사용하여 광고 자산을 자동으로 처리