### PR TITLE
fix: 백그라운드 복귀 시 광고 즉시 재로드

### DIFF
--- a/app/src/main/java/com/trueedu/spac/ui/ads/AdmobManager.kt
+++ b/app/src/main/java/com/trueedu/spac/ui/ads/AdmobManager.kt
@@ -55,14 +55,13 @@ class AdmobManager @Inject constructor(
         // 기존 job이 있으면 취소
         job?.cancel()
 
-        // adLoader가 초기화되지 않았으면 초기화
         if (!::adLoader.isInitialized) {
+            // 최초 초기화: adLoader 생성 + 즉시 로드
             init()
-            return // init()이 loadNativeAd()를 이미 호출함
+        } else {
+            // 포그라운드 복귀 시 즉시 광고 로드
+            loadNativeAd()
         }
-
-        // 포그라운드 복귀 시 즉시 광고 로드
-        loadNativeAd()
 
         job = CoroutineScope(Dispatchers.Main).launch {
             flow {

--- a/app/src/main/java/com/trueedu/spac/ui/ads/AdmobManager.kt
+++ b/app/src/main/java/com/trueedu/spac/ui/ads/AdmobManager.kt
@@ -58,7 +58,11 @@ class AdmobManager @Inject constructor(
         // adLoader가 초기화되지 않았으면 초기화
         if (!::adLoader.isInitialized) {
             init()
+            return // init()이 loadNativeAd()를 이미 호출함
         }
+
+        // 포그라운드 복귀 시 즉시 광고 로드
+        loadNativeAd()
 
         job = CoroutineScope(Dispatchers.Main).launch {
             flow {


### PR DESCRIPTION
## 문제

앱이 백그라운드에서 오래 머물다가 포그라운드로 돌아오면 광고가 로드되지 않는 문제.

## 원인

`ON_STOP` → `ON_START` lifecycle 전환 시:
1. `stop()`에서 `nativeAd`를 `null`로 설정
2. `start()`에서 `adLoader`가 이미 초기화돼 있으므로 `init()` 건너뜀
3. 코루틴 루프가 첫 emit 전에 **1분 대기** → 포그라운드 복귀 후 최대 1분간 광고 없음

## 수정

`start()`에서 `adLoader`가 이미 초기화된 경우 즉시 `loadNativeAd()` 호출.
`init()`을 통한 최초 실행 경로는 `return`으로 중복 로드 방지.

## 변경 파일

- `AdmobManager.kt` — `start()` 함수에 즉시 로드 로직 추가