### PR TITLE
청산 일정 데이터 소스를 Firebase에서 GitHub raw URL로 변경

### DIFF
--- a/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/RefundSchedule.kt
+++ b/app/src/main/java/com/trueedu/spac/api/model/dto/firebase/RefundSchedule.kt
@@ -1,5 +1,8 @@
 package com.trueedu.spac.api.model.dto.firebase
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class RefundSchedule(
     val nameKr: String = "",
     val code: String = "",

--- a/app/src/main/java/com/trueedu/spac/repo/etc/RefundScheduleReader.kt
+++ b/app/src/main/java/com/trueedu/spac/repo/etc/RefundScheduleReader.kt
@@ -1,0 +1,37 @@
+package com.trueedu.spac.repo.etc
+
+import com.trueedu.spac.api.model.dto.firebase.RefundSchedule
+import com.trueedu.spac.data.log.logE
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/**
+ * GitHub raw URL에서 refund.json 을 읽어서 RefundSchedule 목록으로 변환
+ * JSON 포맷: { "종목코드": { code, nameKr, refundAmount, date, fixed }, ... }
+ */
+suspend fun readRefundSchedules(): List<RefundSchedule> = withContext(Dispatchers.IO) {
+    return@withContext try {
+        val url = "https://raw.githubusercontent.com/true-education/true-education.github.io/refs/heads/main/data/refund.json"
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 10_000
+
+        val text = connection.inputStream.bufferedReader().use { it.readText() }
+
+        val map = json.decodeFromString(
+            MapSerializer(String.serializer(), RefundSchedule.serializer()),
+            text
+        )
+        map.values.sortedBy { it.date }
+    } catch (e: Exception) {
+        logE("Failed to read refund schedules", e)
+        emptyList()
+    }
+}

--- a/app/src/main/java/com/trueedu/spac/ui/refund/RefundScheduleViewModel.kt
+++ b/app/src/main/java/com/trueedu/spac/ui/refund/RefundScheduleViewModel.kt
@@ -7,15 +7,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.trueedu.spac.api.model.dto.firebase.RefundSchedule
 import com.trueedu.spac.data.log.logD
-import com.trueedu.spac.repo.firebase.FirebaseRefundDatabase
+import com.trueedu.spac.repo.etc.readRefundSchedules
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class RefundScheduleViewModel @Inject constructor(
-    private val refundDatabase: FirebaseRefundDatabase
-) : ViewModel() {
+class RefundScheduleViewModel @Inject constructor() : ViewModel() {
 
     var loading by mutableStateOf(false)
         private set
@@ -31,8 +29,7 @@ class RefundScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             loading = true
             try {
-                schedules = refundDatabase.loadRefundSchedule()
-                    .sortedBy { it.date }
+                schedules = readRefundSchedules()
                 logD("Loaded ${schedules.size} refund schedules")
             } catch (e: Exception) {
                 logD("Failed to load refund schedules: ${e.message}")


### PR DESCRIPTION
## 변경 내용

청산 일정 데이터를 Firebase Realtime Database 대신 GitHub raw URL에서 직접 읽도록 변경

### 수정 파일
- `RefundSchedule.kt` — `@Serializable` 어노테이션 추가
- `RefundScheduleReader.kt` (신규) — `refund.json` 파싱 suspend 함수
- `RefundScheduleViewModel.kt` — Firebase 의존성 제거, `readRefundSchedules()` 호출로 교체

### 데이터 소스
```
https://raw.githubusercontent.com/true-education/true-education.github.io/refs/heads/main/data/refund.json
```